### PR TITLE
Feature/ 임시파일 삭제

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -48,9 +48,9 @@ public class FileController {
     // 3. 임시 파일 삭제 API (hard delete)
     @DeleteMapping("files/{fileId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteTempFile(@PathVariable Long projectId, @PathVariable Long fileId)
+    public void deleteTempFile(@PathVariable Long projectId, @RequestBody FileDeleteRequest request)
     {
-        fileService.deleteFile(projectId,fileId);
+        fileService.deleteFile(projectId,request.getFileId());
     }
 
     // 4. 업로드 된 파일 삭제 API (soft delete)

--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -50,7 +50,7 @@ public class FileController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteTempFile(@PathVariable Long projectId, @RequestBody FileDeleteRequest request)
     {
-        fileService.deleteFile(projectId,request.getFileId());
+        fileService.deleteFile(projectId,request.getFileIds());
     }
 
     // 4. 업로드 된 파일 삭제 API (soft delete)

--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.service.FileService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -41,5 +42,15 @@ public class FileController {
     {
         Long loginUserId = SessionUtil.getLoginUserId(session);
         fileService.deletePostFiles(projectId, postId, fileId, loginUserId);
+    }
+
+    // 임시 파일 삭제 API (hard delete)
+    @DeleteMapping("/delete")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void s3Delete(
+            @PathVariable String projectId,
+            @RequestBody FileDeleteRequest fileDeleteRequest)
+    {
+        fileService.s3Delete(projectId,fileDeleteRequest);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -45,9 +45,15 @@ public class FileController {
         return CommonResponse.success("파일 업로드 성공", response);
     }
 
-    // todo: 3. 임시 파일 삭제 API
+    // 3. 임시 파일 삭제 API (hard delete)
+    @DeleteMapping("files/{fileId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTempFile(@PathVariable Long projectId, @PathVariable Long fileId)
+    {
+        fileService.deleteFile(projectId,fileId);
+    }
 
-    // 4. 업로드 된 파일 삭제 API
+    // 4. 업로드 된 파일 삭제 API (soft delete)
     @DeleteMapping("/posts/{postId}/files/{fileId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePostFiles(
@@ -58,15 +64,5 @@ public class FileController {
     {
         Long loginUserId = SessionUtil.getLoginUserId(session);
         fileService.deletePostFiles(projectId, postId, fileId, loginUserId);
-    }
-
-    // 임시 파일 삭제 API (hard delete)
-    @DeleteMapping("/delete")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void s3Delete(
-            @PathVariable String projectId,
-            @RequestBody FileDeleteRequest fileDeleteRequest)
-    {
-        fileService.s3Delete(projectId,fileDeleteRequest);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -46,7 +46,7 @@ public class FileController {
     }
 
     // 3. 임시 파일 삭제 API (hard delete)
-    @DeleteMapping("files/{fileId}")
+    @DeleteMapping("files")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteTempFile(@PathVariable Long projectId, @RequestBody FileDeleteRequest request)
     {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
@@ -11,5 +11,5 @@ import java.util.List;
 @AllArgsConstructor
 public class FileDeleteRequest {
 
-    private List<Long> fileId;
+    private List<Long> fileIds;
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
@@ -1,0 +1,15 @@
+package org.etmetmy.bn_server.domain.file.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileDeleteRequest {
+
+    private List<String> fileUrls;
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileDeleteRequest.java
@@ -11,5 +11,5 @@ import java.util.List;
 @AllArgsConstructor
 public class FileDeleteRequest {
 
-    private List<String> fileUrls;
+    private List<Long> fileId;
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.file.service;
 
 import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.file.dto.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 
 import java.util.List;
 
@@ -10,7 +11,9 @@ public interface FileService {
     //프로젝트별 파일 목록 조회
     List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session);
 
-    // 업로드 된 파일 삭제
+    // 업로드 된 파일 삭제 (soft delete)
     void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
 
+    // 임시 업로드 파일 삭제 (hard delete)
+    void s3Delete(String projectId, FileDeleteRequest fileDeleteRequest);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -12,12 +12,12 @@ public interface FileService {
     //프로젝트별 파일 목록 조회
     List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session);
 
-    // 업로드 된 파일 삭제 (soft delete)
-    void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
-
-    // 임시 업로드 파일 삭제 (hard delete)
-    void s3Delete(String projectId, FileDeleteRequest fileDeleteRequest);
-
     // 임시 파일 업로드
     List<ActiveFileListDTO> postFiles(Long projectId, Long postId, List<MultipartFile> files);
+
+    // 임시 업로드 파일 삭제 (hard delete)
+    void deleteFile(Long projectId, Long fileId);
+
+    // 업로드 된 파일 삭제 (soft delete)
+    void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -16,7 +16,7 @@ public interface FileService {
     List<ActiveFileListDTO> postFiles(Long projectId, Long postId, List<MultipartFile> files);
 
     // 임시 업로드 파일 삭제 (hard delete)
-    void deleteFile(Long projectId, Long fileId);
+    void deleteFile(Long projectId, List<Long> fileIds);
 
     // 업로드 된 파일 삭제 (soft delete)
     void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -3,6 +3,7 @@ package org.etmetmy.bn_server.domain.file.service;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
 import org.etmetmy.bn_server.domain.post.entity.Post;
@@ -85,6 +86,11 @@ public class FileServiceImpl implements FileService {
         file.softDelete(loginUserId);
 
         fileRepository.save(file);
+    }
+
+    // 임시 업로드 파일 삭제 (hard delete)
+    public void s3Delete(String projectId, FileDeleteRequest fileDeleteRequest){
+
 
     }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -24,10 +24,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -45,7 +50,7 @@ public class FileServiceImpl implements FileService {
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
 
-    //프로젝트별 파일 목록 조회
+    // 1. 프로젝트별 파일 목록 조회
     @Override
     public List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session){
 
@@ -69,7 +74,7 @@ public class FileServiceImpl implements FileService {
 
     }
 
-    // 임시 파일 업로드
+    // 2. 임시 파일 업로드
     @Override
     @Transactional
     public List<ActiveFileListDTO> postFiles(Long projectId, Long postId, List<MultipartFile> files){
@@ -104,8 +109,36 @@ public class FileServiceImpl implements FileService {
         return ActiveFileListDTO.Converter.from(savedFiles);
     }
 
+    // 3. S3 파일 삭제 (hard delete)
+    public void deleteFile(Long projectId, Long fileId) {
 
-    // 업로드 된 파일 삭제 API
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
+
+        String fileUrl = file.getFilePath();
+
+        try {
+            // S3 key 추출
+            String key = getKeyFromFileUrls(fileUrl);
+
+            // S3 삭제 요청
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+
+            // DB 레코드 삭제
+            fileRepository.deleteById(fileId);
+
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+
+    // 5. 업로드 된 파일 삭제 (soft delete)
     @Override
     @Transactional
     public void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId){
@@ -135,12 +168,6 @@ public class FileServiceImpl implements FileService {
         file.softDelete(loginUserId);
 
         fileRepository.save(file);
-    }
-
-    // 임시 업로드 파일 삭제 (hard delete)
-    public void s3Delete(String projectId, FileDeleteRequest fileDeleteRequest){
-
-
     }
 
     // URL 에서 파일명 추출
@@ -178,5 +205,19 @@ public class FileServiceImpl implements FileService {
         }
         return s3Client.utilities().getUrl(url -> url.bucket(bucketName).key(s3FileName))
                 .toString();
+    }
+
+    // 삭제에 필요한 key 반환
+    private String getKeyFromFileUrls(String fileUrl) {
+        try{
+            URL url = new URI(fileUrl).toURL();
+            String decodedKey = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
+
+            //경로 앞에 '/' 제거 후 반환
+            return decodedKey.substring(1);
+        }
+        catch (Exception e){
+            throw new BusinessException(ErrorCode.INVALID_URL_FORMAT);
+        }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -110,11 +110,20 @@ public class FileServiceImpl implements FileService {
     }
 
     // 3. 파일 삭제 (hard delete)
+    @Override
+    @Transactional
     public void deleteFile(Long projectId, List<Long> fileIds){
 
         List<File> files = fileRepository.findAllById(fileIds);
 
-        if (files.isEmpty()) {
+        // 파일들이 해당 프로젝트에 속하는지 검증 (악의적 요청 가정)
+        for (File file : files) {
+            if (!file.getPost().getProject().getId().equals(projectId)) {
+                throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
+            }
+        }
+        // 일부만 있어도 에러 발생
+        if (files.size() != fileIds.size()) {
             throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
         }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -116,15 +116,18 @@ public class FileServiceImpl implements FileService {
 
         List<File> files = fileRepository.findAllById(fileIds);
 
-        // 파일들이 해당 프로젝트에 속하는지 검증 (악의적 요청 가정)
-        for (File file : files) {
-            if (!file.getPost().getProject().getId().equals(projectId)) {
-                throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
-            }
-        }
-        // 일부만 있어도 에러 발생
+        // 파일 개수 검증
         if (files.size() != fileIds.size()) {
             throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        // 프로젝트 소속 검증 (악의적 요청 가정)
+        for (File file : files) {
+            if (file.getPost() == null ||
+                    file.getPost().getProject() == null ||
+                    !file.getPost().getProject().getId().equals(projectId)) {
+                throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
+            }
         }
 
         for (File file : files) {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -109,34 +109,39 @@ public class FileServiceImpl implements FileService {
         return ActiveFileListDTO.Converter.from(savedFiles);
     }
 
-    // 3. S3 파일 삭제 (hard delete)
-    public void deleteFile(Long projectId, Long fileId) {
+    // 3. 파일 삭제 (hard delete)
+    public void deleteFile(Long projectId, List<Long> fileIds){
 
-        File file = fileRepository.findById(fileId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
+        List<File> files = fileRepository.findAllById(fileIds);
 
-        String fileUrl = file.getFilePath();
+        if (files.isEmpty()) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
 
-        try {
-            // S3 key 추출
-            String key = getKeyFromFileUrls(fileUrl);
+        for (File file : files) {
+            try {
+                String fileUrl = file.getFilePath();
+                Long fileId = file.getFileId();
 
-            // S3 삭제 요청
-            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(key)
-                    .build();
+                // S3 key 추출
+                String key = getKeyFromFileUrls(fileUrl);
 
-            s3Client.deleteObject(deleteRequest);
+                // S3 삭제 요청
+                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build();
 
-            // DB 레코드 삭제
-            fileRepository.deleteById(fileId);
+                s3Client.deleteObject(deleteRequest);
 
-        } catch (Exception e) {
-            throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+                // DB 레코드 삭제
+                fileRepository.deleteById(fileId);
+
+            } catch (Exception e) {
+                throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+            }
         }
     }
-
 
     // 5. 업로드 된 파일 삭제 (soft delete)
     @Override

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 import org.etmetmy.bn_server.domain.post.service.PostService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -36,6 +37,20 @@ public class PostController {
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
         PostCreateResponse response = postService.createPost(projectId, requestDto, loginUserId);
+        return CommonResponse.success("게시글 작성 성공", response);
+    }
+
+    // todo: reply 게시글 작성 API
+    @PostMapping("/{projectId}/posts/{postId}")
+    public CommonResponse<ReplyPostCreateResponse> createReplyPost(
+            @PathVariable Long projectId,
+            @Valid @RequestBody PostCreateRequest requestDto,
+            @PathVariable Long postId,
+            HttpSession session) {
+
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+
+        ReplyPostCreateResponse response = postService.createReplyPost(projectId, requestDto, postId, loginUserId);
         return CommonResponse.success("게시글 작성 성공", response);
     }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -56,5 +56,25 @@ public class PostCreateRequest {
                     .isCompleted(false)
                     .build();
         }
+        public static Post toReplyEntity(
+                Project project,
+                User user,
+                Post post,
+                String title,
+                String content,
+                Stage stage,
+                Long postNumber) {
+
+            return Post.builder()
+                    .project(project)
+                    .user(user)
+                    .parentPostId(post.getPostId()) //일반 게시글은 부모 없음
+                    .title(title)
+                    .content(content)
+                    .stage(stage)
+                    .postNumber(postNumber)
+                    .isCompleted(false)
+                    .build();
+        }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
@@ -53,7 +53,7 @@ public class PostCreateResponse {
 
     public static class Converter {
         public static PostCreateResponse from(
-                Post post, List<File> files, List<Link> links
+            Post post, List<File> files, List<Link> links
         ) {
             // 파일 목록 변환 (삭제되지 않은 파일만)
             List<FileInfoDTO> fileInfos = FileInfoDTO.Converter.from(files);

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 
 import java.util.List;
 
@@ -21,6 +22,8 @@ public interface PostService {
     List<PostListResponse> getPostListByProjectIdAndFilter(Long projectId, String filter);
 
     PostCreateResponse createPost(Long projectId, @Valid PostCreateRequest requestDto, Long loginUserId);
+
+    ReplyPostCreateResponse createReplyPost(Long projectId, @Valid PostCreateRequest requestDto, Long postId, Long loginUserId);
 
     List<PostListResponse> getPostListByStage(Long projectId, String stage);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -13,6 +13,7 @@ import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 import org.etmetmy.bn_server.domain.post.entity.*;
 import org.etmetmy.bn_server.domain.post.repository.PostNumberCounterRepository;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
@@ -179,6 +180,58 @@ public class PostServiceImpl implements PostService {
 
         // 6. 응답 반환
         return PostCreateResponse.Converter.from(savedPost, savedFiles, savedLinks);
+    }
+
+    @Override
+    @Transactional
+    public ReplyPostCreateResponse createReplyPost(Long projectId, PostCreateRequest requestDto, Long postId, Long loginUserId) {
+
+        // 1. 필요한 엔티티 조회
+        User user = userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(ProjectNotFoundException::new);
+        Stage stage = stageRepository.findById(requestDto.getStageId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(BoardNotFoundException::new);
+
+        // 2. Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
+        PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
+                .orElseGet(() -> PostNumberCounter.builder()
+                        .projectId(projectId)
+                        .currentNumber(0L)
+                        .build());
+        Long postNumber = counter.getNextNumber();
+        postNumberCounterRepository.save(counter);
+
+        // 3. Post 엔티티 생성 및 저장
+        Post replyPost = PostCreateRequest.Converter.toReplyEntity(project, user,post, requestDto.getTitle(), requestDto.getContent(), stage, postNumber);
+        Post savedPost = postRepository.save(replyPost);
+
+        // 4. 파일 처리
+        List<File> savedFiles = new ArrayList<>();
+        if (requestDto.getFileUrls() != null && !requestDto.getFileUrls().isEmpty()) {
+            for (String fileUrl : requestDto.getFileUrls()) {
+                File file = FileCreateRequest.Converter.toEntity(fileUrl, savedPost, loginUserId);
+                savedFiles.add(file);
+            }
+            fileRepository.saveAll(savedFiles);
+        }
+
+        // 5. 링크 처리
+
+        List<Link> savedLinks = new ArrayList<>();
+        if (requestDto.getLinkUrls() != null && !requestDto.getLinkUrls().isEmpty()) {
+            for (String linkUrl : requestDto.getLinkUrls()) {
+                Link link = LinkCreateRequest.Converter.toEntity(linkUrl, savedPost, loginUserId);
+                savedLinks.add(link);
+            }
+            linkRepository.saveAll(savedLinks);
+        }
+
+        // 6. 응답 반환
+        return ReplyPostCreateResponse.Converter.from(savedPost, post, savedFiles, savedLinks);
     }
 
     // 게시글 업데이트 API

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -53,6 +53,8 @@ public enum ErrorCode {
     INVALID_FILE_TYPE(400, "F003", "지원하지 않는 파일 형식입니다"),
     FILE_UPLOAD_FAILED(500, "F004", "파일 업로드에 실패했습니다"),
     FILE_NOT_IN_POST(400, "F005", "파일이 해당 게시글에 속하지 않습니다."),
+    INVALID_URL_FORMAT(400,"C005", "잘못된 URL 형식입니다."),
+    FILE_DELETE_FAILED(500, "F006", "파일 삭제에 실패했습니다"),
 
     // 체크리스트 관련 에러
     CHECKLIST_NOT_FOUND(404,"D001","체크리스트를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
- 게시글 업로드 전 임시 파일 일괄 삭제 기능 구현 (Hard Delete)
- 여러 임시 파일을 한 번의 API 호출로 삭제 가능하도록 개선

  **구현 내용**
  - 파일 존재 여부 검증 (요청한 ID 수와 조회된 파일 수 일치 확인)
  - 프로젝트 소속 검증 (다른 프로젝트 파일 삭제 방지)
  - S3 객체 삭제 → DB 레코드 삭제 (트랜잭션 처리)
  - 일괄 처리 실패 시 전체 롤백

  **보안**
  - 요청된 파일들이 해당 프로젝트에 속하는지 검증
  - 악의적 요청 차단 (다른 프로젝트의 파일 ID 전송 방지)
  
<img width="710" height="306" alt="image" src="https://github.com/user-attachments/assets/3059494d-cfb8-456a-818b-902ead5ec0e5" />

## 테스트 확인
- [x] db 삭제 확인
- [x] s3 삭제 확인

## 📎 Issue 95

<!-- closed 95 -->
