### PR TITLE
fix: 프로젝트 목록 조회(권한)

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/checkList/controller/CheckListController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/checkList/controller/CheckListController.java
@@ -1,6 +1,7 @@
 package org.etmetmy.bn_server.domain.checkList.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.checkList.dto.request.CheckListCreateRequest;
 import org.etmetmy.bn_server.domain.checkList.dto.request.CheckListUpdateRequest;
 import org.etmetmy.bn_server.domain.checkList.dto.response.CheckListResponse;
 import org.etmetmy.bn_server.domain.checkList.service.CheckListService;
@@ -20,8 +21,8 @@ public class CheckListController {
 
     // todo : 체크리스트 생성
     @PostMapping
-    public CommonResponse<CheckListResponse> createCheckList() {
-        return CommonResponse.success("체크리스트를 생성했습니다", checkListService.save());
+    public CommonResponse<CheckListResponse> createCheckList(@RequestBody CheckListCreateRequest request) {
+        return CommonResponse.success("체크리스트를 생성했습니다", checkListService.save(request));
     }
 
     // todo : 체크리스트 수정

--- a/src/main/java/org/etmetmy/bn_server/domain/checkList/dto/request/CheckListCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/checkList/dto/request/CheckListCreateRequest.java
@@ -7,12 +7,13 @@ import org.etmetmy.bn_server.domain.checkList.entity.CheckList;
 @Getter
 @NoArgsConstructor
 public class CheckListCreateRequest {
+    private String content;
     // 내부 Converter
     public static class Converter{
 
-        public static CheckList toEntity() {
+        public static CheckList toEntity(CheckListCreateRequest request) {
             return CheckList.builder()
-                    .content(null)
+                    .content(request.getContent())
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/checkList/service/CheckListService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/checkList/service/CheckListService.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.checkList.service;
 
+import org.etmetmy.bn_server.domain.checkList.dto.request.CheckListCreateRequest;
 import org.etmetmy.bn_server.domain.checkList.dto.request.CheckListUpdateRequest;
 import org.etmetmy.bn_server.domain.checkList.dto.response.CheckListResponse;
 import org.etmetmy.bn_server.global.page.PageRequest;
@@ -7,7 +8,7 @@ import org.springframework.data.domain.Page;
 
 public interface CheckListService {
 
-    CheckListResponse save();
+    CheckListResponse save(CheckListCreateRequest request);
 
     CheckListResponse update(Long checkListId, CheckListUpdateRequest request);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/checkList/service/CheckListServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/checkList/service/CheckListServiceImpl.java
@@ -22,8 +22,8 @@ public class CheckListServiceImpl implements CheckListService {
     private final CheckListRepository checkListRepository;
 
     @Override
-    public CheckListResponse save() {
-        CheckList entity = CheckListCreateRequest.Converter.toEntity();
+    public CheckListResponse save(CheckListCreateRequest request) {
+        CheckList entity = CheckListCreateRequest.Converter.toEntity(request);
         CheckList saved = checkListRepository.save(entity);
         return CheckListResponse.Converter.from(saved);
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
@@ -1,0 +1,31 @@
+package org.etmetmy.bn_server.domain.dashboard.controller;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ProjectListResponse;
+import org.etmetmy.bn_server.domain.dashboard.service.DashBoardService;
+import org.etmetmy.bn_server.global.CommonResponse;
+import org.etmetmy.bn_server.global.util.SessionUtil;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dashboard")
+public class DashBoardController {
+
+    private final DashBoardService dashBoardService;
+
+    //todo: 프로젝트 목록 조회 API
+    @GetMapping("/projects")
+    public CommonResponse<List<ProjectListResponse>> getProjectList(HttpSession session)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        List<ProjectListResponse> response = dashBoardService.getProjectList(loginUserId);
+
+        return CommonResponse.success("프로젝트 목록 조회 성공", response);
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ProjectListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ProjectListResponse.java
@@ -5,12 +5,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.project.dto.response.ProjectResponse;
 import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.project.entity.ProjectMember;
 import org.etmetmy.bn_server.domain.user.entity.User;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -46,19 +50,20 @@ public class ProjectListResponse {
     private boolean hasPermission;
 
     public static class Converter {
-        public static ProjectListResponse from(Project project, Boolean hasPermission) {
-
-            return ProjectListResponse.builder()
-                    .projectId(project.getId())
-                    .projectImageUrl(project.getProjectImageUrl())
-                    .projectName(project.getProjectName())
-                    .companyName(project.getCompany().getCompanyName())
-                    .stage(project.getStage().getStageName())
-                    .startDate(project.getStartDate())
-                    .endDate(project.getEndDate())
-                    .updateAt(project.getUpdatedAt())
-                    .hasPermission(hasPermission)
-                    .build();
+        public static List<ProjectListResponse> from(List<Project> projects, List<Long> myProjectIds) {
+            return projects.stream()
+                    .map(project -> ProjectListResponse.builder()
+                            .projectId(project.getId())
+                            .projectImageUrl(project.getProjectImageUrl())
+                            .projectName(project.getProjectName())
+                            .companyName(project.getCompany().getCompanyName())
+                            .stage(project.getStage().getStageName())
+                            .startDate(project.getStartDate())
+                            .endDate(project.getEndDate())
+                            .updateAt(project.getUpdatedAt())
+                            .hasPermission(myProjectIds.contains(project.getId()))
+                            .build()
+                    ).toList();
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ProjectListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ProjectListResponse.java
@@ -1,0 +1,64 @@
+package org.etmetmy.bn_server.domain.dashboard.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.project.entity.Project;
+import org.etmetmy.bn_server.domain.project.entity.ProjectMember;
+import org.etmetmy.bn_server.domain.user.entity.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectListResponse {
+
+    @JsonProperty("project_id")
+    private Long projectId;
+
+    @JsonProperty("project_image_url")
+    private String projectImageUrl;
+
+    @JsonProperty("project_name")
+    private String projectName;
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("stage")
+    private String stage;
+
+    @JsonProperty("start_date")
+    private LocalDate startDate;
+
+    @JsonProperty("end_date")
+    private LocalDate endDate;
+
+    @JsonProperty("update_at")
+    private LocalDateTime updateAt;
+
+    @JsonProperty("has_permission")
+    private boolean hasPermission;
+
+    public static class Converter {
+        public static ProjectListResponse from(Project project, Boolean hasPermission) {
+
+            return ProjectListResponse.builder()
+                    .projectId(project.getId())
+                    .projectImageUrl(project.getProjectImageUrl())
+                    .projectName(project.getProjectName())
+                    .companyName(project.getCompany().getCompanyName())
+                    .stage(project.getStage().getStageName())
+                    .startDate(project.getStartDate())
+                    .endDate(project.getEndDate())
+                    .updateAt(project.getUpdatedAt())
+                    .hasPermission(hasPermission)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
@@ -1,0 +1,11 @@
+package org.etmetmy.bn_server.domain.dashboard.service;
+
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ProjectListResponse;
+
+import java.util.List;
+
+public interface DashBoardService {
+
+    // 프로젝트 목록 조회
+    List<ProjectListResponse> getProjectList(Long loginUserId);
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -20,11 +20,11 @@ public class DashBoardServiceImpl implements DashBoardService{
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
 
+    // 1. 프로젝트 목록 조회 (접근 권한 정보 제공)
     public List<ProjectListResponse> getProjectList(Long loginUserId){
 
         // 유저 검증
-        User user = userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
 
         // 모든 프로젝트 목록 조회
         List<Project> allProjects = projectRepository.findAll();

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -32,9 +32,6 @@ public class DashBoardServiceImpl implements DashBoardService{
         // 권한이 있는 모든 프로젝트 조회
         List<Long> myProjectIds = projectMemberRepository.findProjectIdsByUserId(loginUserId);
 
-        return allProjects.stream()
-                .map(project -> ProjectListResponse.Converter.from(
-                                project, myProjectIds.contains(project.getId())
-                                )).toList();
+        return ProjectListResponse.Converter.from(allProjects, myProjectIds);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -1,0 +1,40 @@
+package org.etmetmy.bn_server.domain.dashboard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ProjectListResponse;
+import org.etmetmy.bn_server.domain.project.entity.Project;
+import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
+import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
+import org.etmetmy.bn_server.domain.user.entity.User;
+import org.etmetmy.bn_server.domain.user.repository.UserRepository;
+import org.etmetmy.bn_server.exception.custom.UserNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashBoardServiceImpl implements DashBoardService{
+
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    public List<ProjectListResponse> getProjectList(Long loginUserId){
+
+        // 유저 검증
+        User user = userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 모든 프로젝트 목록 조회
+        List<Project> allProjects = projectRepository.findAll();
+
+        // 권한이 있는 모든 프로젝트 조회
+        List<Long> myProjectIds = projectMemberRepository.findProjectIdsByUserId(loginUserId);
+
+        return allProjects.stream()
+                .map(project -> ProjectListResponse.Converter.from(
+                                project, myProjectIds.contains(project.getId())
+                                )).toList();
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
@@ -10,7 +10,6 @@ import org.etmetmy.bn_server.domain.project.service.ProjectMemberService;
 import org.etmetmy.bn_server.domain.project.service.ProjectService;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.global.CommonResponse;
-import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.etmetmy.bn_server.web.SessionConst;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -27,6 +27,9 @@ public class Project extends BaseEntity {
     @Column(name = "project_id")
     private Long id;
 
+    @Column(name = "project_image_url")
+    private String projectImageUrl;
+
     @Column(name = "project_name", nullable = false, length = 255)
     private String projectName;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -9,8 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-import static org.etmetmy.bn_server.domain.user.entity.QUser.user;
-
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
 
@@ -22,12 +20,12 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     boolean existsByProjectIdAndUserId(@Param("projectId") Long projectId,
                                        @Param("userId") Long userId);
 
-    // 프로젝트 + 유저 기준으로 매핑 삭제
-    long deleteByProjectIdAndUserId(Long projectId, Long userId);
-
     List<ProjectMember> findByProjectId(Long projectId);
     List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
     ProjectMember findByUserIdAndProjectId(Long userId, Long projectId);
+
+    // 프로젝트 + 유저 기준으로 매핑 삭제
+    long deleteByProjectIdAndUserId(Long projectId, Long userId);
     
     // 권한이 있는 모든 프로젝트 조회
     @Query("""

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -17,8 +17,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
            "FROM ProjectMember pm " +
            "WHERE pm.project.id = :projectId " +
            "AND pm.user.id = :userId")
-    boolean existsByProjectIdAndUserId(@Param("projectId") Long projectId,
-                                       @Param("userId") Long userId);
+    boolean existsByProjectIdAndUserId(@Param("projectId") Long projectId, @Param("userId") Long userId);
 
     List<ProjectMember> findByProjectId(Long projectId);
     List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
@@ -34,6 +33,4 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     where pm.user.id = :userId
     """)
     List<Long> findProjectIdsByUserId(@Param("userId") Long userId);
-
-    boolean existsByProjectIdAndUserId(Long projectId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -14,10 +14,6 @@ import static org.etmetmy.bn_server.domain.user.entity.QUser.user;
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
 
-    List<ProjectMember> findByProjectId(Long projectId);
-    List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
-    ProjectMember findByUserIdAndProjectId(Long userId, Long projectId);
-
     //사용자가 특정 프로젝트의 멤버인지 확인
     @Query("SELECT CASE WHEN COUNT(pm) > 0 THEN true ELSE false END " +
            "FROM ProjectMember pm " +
@@ -29,6 +25,10 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     // 프로젝트 + 유저 기준으로 매핑 삭제
     long deleteByProjectIdAndUserId(Long projectId, Long userId);
 
+    List<ProjectMember> findByProjectId(Long projectId);
+    List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
+    ProjectMember findByUserIdAndProjectId(Long userId, Long projectId);
+    
     // 권한이 있는 모든 프로젝트 조회
     @Query("""
     select pm.project.id

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.project.repository;
 
+import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.project.entity.ProjectMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,20 +9,25 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static org.etmetmy.bn_server.domain.user.entity.QUser.user;
+
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
-
-    //사용자가 특정 프로젝트의 멤버인지 확인
-    @Query("SELECT CASE WHEN COUNT(pm) > 0 THEN true ELSE false END " +
-           "FROM ProjectMember pm " +
-           "WHERE pm.project.id = :projectId " +
-           "AND pm.user.id = :userId")
-    boolean existsByProjectIdAndUserId(@Param("projectId") Long projectId,
-                                       @Param("userId") Long userId);
 
     List<ProjectMember> findByProjectId(Long projectId);
     List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
     ProjectMember findByUserIdAndProjectId(Long userId, Long projectId);
+
     // 프로젝트 + 유저 기준으로 매핑 삭제
     long deleteByProjectIdAndUserId(Long projectId, Long userId);
+
+    // 권한이 있는 모든 프로젝트 조회
+    @Query("""
+    select pm.project.id
+    from ProjectMember pm
+    where pm.user.id = :userId
+    """)
+    List<Long> findProjectIdsByUserId(@Param("userId") Long userId);
+
+    boolean existsByProjectIdAndUserId(Long projectId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -18,6 +18,14 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     List<ProjectMember> findByProjectIdIn(List<Long> projectIds);
     ProjectMember findByUserIdAndProjectId(Long userId, Long projectId);
 
+    //사용자가 특정 프로젝트의 멤버인지 확인
+    @Query("SELECT CASE WHEN COUNT(pm) > 0 THEN true ELSE false END " +
+           "FROM ProjectMember pm " +
+           "WHERE pm.project.id = :projectId " +
+           "AND pm.user.id = :userId")
+    boolean existsByProjectIdAndUserId(@Param("projectId") Long projectId,
+                                       @Param("userId") Long userId);
+
     // 프로젝트 + 유저 기준으로 매핑 삭제
     long deleteByProjectIdAndUserId(Long projectId, Long userId);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -1,6 +1,5 @@
 package org.etmetmy.bn_server.domain.project.repository;
 
-import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.project.entity.ProjectMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;


### PR DESCRIPTION
## 📄 작업 내용 요약
- 대시보드에서 모든 프로젝트를 조회하고, 사용자별 접근 권한 정보를 함께 제공하는 기능 구현
- 프로젝트 목록 조회 시 사용자의 권한 여부를 `hasPermission` 필드로 반환
 ### 엔티티 수정
   - **Project 엔티티**
     - `projectImageUrl` 필드 추가

<img width="1912" height="168" alt="image" src="https://github.com/user-attachments/assets/a8769cd6-ba4c-41fa-86b9-8cc82487d82d" />
<img width="1016" height="1382" alt="image" src="https://github.com/user-attachments/assets/f04a4c4a-7fa3-4d56-b3de-a44c9d6b06bb" />
<img width="724" height="372" alt="image" src="https://github.com/user-attachments/assets/a058f6b5-dd88-4377-8844-e900e50e2223" />

## 📎 Issue 109

<!-- closed #109 -->
