### PR TITLE
Feat/ 삭제된 프로젝트 목록 조회

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
@@ -26,7 +26,7 @@ public class DashBoardController {
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
         DashBoardResponse result = dashBoardService.getStatusDashboard(loginUserId);
-        return CommonResponse.success("성공", result);
+        return CommonResponse.success("상태 게시글 조회 성공", result);
     }
 
     //todo: 프로젝트 목록 조회 API

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
@@ -20,7 +20,7 @@ public class DashBoardController {
 
     private final DashBoardService dashBoardService;
 
-    // 관리자 메인대시보드 상태 조회 (STATUS_PENDING인 Post 목록 및 통계)
+    //todo: 관리자 메인 대시보드 상태 조회 API (STATUS_PENDING인 Post 목록 및 통계)
     @GetMapping
     public CommonResponse<DashBoardResponse> getStatusDashboard(HttpSession session) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
@@ -28,6 +28,7 @@ public class DashBoardController {
         DashBoardResponse result = dashBoardService.getStatusDashboard(loginUserId);
         return CommonResponse.success("성공", result);
     }
+
     //todo: 프로젝트 목록 조회 API
     @GetMapping("/projects")
     public CommonResponse<List<ProjectListResponse>> getProjectList(HttpSession session)

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -33,8 +33,8 @@ public class DashBoardServiceImpl implements DashBoardService{
         // 유저 검증
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
 
-        // 모든 프로젝트 목록 조회
-        List<Project> allProjects = projectRepository.findAll();
+        // 삭제되지 않은 모든 프로젝트 목록 조회
+        List<Project> allProjects = projectRepository.findActiveProjects();
 
         // 권한이 있는 모든 프로젝트 조회
         List<Long> myProjectIds = projectMemberRepository.findProjectIdsByUserId(loginUserId);
@@ -52,7 +52,6 @@ public class DashBoardServiceImpl implements DashBoardService{
         // STATUS_PENDING(요청대기) 상태인 Post 목록
         List<Post> pendingPosts = postRepository.findPostsWithRequestStatus(RequestStatus.STATUS_PENDING);
         List<DashBoardStatusResponseDTO> pendingList = DashBoardStatusResponseDTO.Converter.toPostDTOList(pendingPosts, RequestStatus.STATUS_PENDING);
-
 
         // STATUS_REJECTED(반려) 상태인 Post 목록
         List<Post> rejectedPosts = postRepository.findPostsWithRequestStatus(RequestStatus.STATUS_REJECTED);

--- a/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
@@ -10,6 +10,7 @@ import org.etmetmy.bn_server.domain.project.service.ProjectMemberService;
 import org.etmetmy.bn_server.domain.project.service.ProjectService;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.global.CommonResponse;
+import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.etmetmy.bn_server.web.SessionConst;
 import org.springframework.web.bind.annotation.*;
 
@@ -156,5 +157,15 @@ public class ProjectController {
     public CommonResponse<List<ProjectMemberSearchResponse>> searchClientsForCreate() {
         List<ProjectMemberSearchResponse> responses = projectMemberService.searchClientMembers();
         return CommonResponse.success("고객사 사원 조회 성공", responses);
+    }
+
+    //todo: 삭제된 프로젝트 목록 조회
+    @GetMapping("/trash")
+    public CommonResponse<List<DeletedProjectResponse>> getDeletedProjectList(HttpSession session)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        List<DeletedProjectResponse> response = projectService.getDeletedProjectList(loginUserId);
+
+        return CommonResponse.success("삭제된 프로젝트 목록 조회", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/DeletedProjectResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/DeletedProjectResponse.java
@@ -1,0 +1,52 @@
+package org.etmetmy.bn_server.domain.project.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.project.entity.Project;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeletedProjectResponse {
+
+    @JsonProperty("project_id")
+    private Long projectId;
+
+    @JsonProperty("project_image_url")
+    private String projectImageUrl;
+
+    @JsonProperty("project_name")
+    private String projectName;
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("create_date")
+    private LocalDate createDate;
+
+    @JsonProperty("delete_date")
+    private LocalDate deleteDate;
+
+    public static class Converter {
+        public static List<DeletedProjectResponse> from(List<Project> projects) {
+            return projects.stream()
+                    .map(project -> DeletedProjectResponse.builder()
+                            .projectId(project.getId())
+                            .projectImageUrl(project.getProjectImageUrl())
+                            .projectName(project.getProjectName())
+                            .companyName(project.getCompany().getCompanyName())
+                            .createDate(LocalDate.from(project.getCreatedAt()))
+                            .deleteDate(LocalDate.from(project.getDeletedAt()))
+                            .build()
+                    ).toList();
+        }
+    }
+}
+

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectMemberRepository.java
@@ -26,10 +26,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     long deleteByProjectIdAndUserId(Long projectId, Long userId);
     
     // 권한이 있는 모든 프로젝트 조회
-    @Query("""
-    select pm.project.id
-    from ProjectMember pm
-    where pm.user.id = :userId
-    """)
+    @Query("select pm.project.id from ProjectMember pm " +
+            "where pm.user.id = :userId and pm.project.isDeleted != false")
     List<Long> findProjectIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectRepository.java
@@ -63,5 +63,11 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             "ORDER BY p.createdAt DESC")
     List<Project> findProjectsMaintenance();
 
+    // 삭제되지 않은 모든 프로젝트 조회
+    @Query("select p from Project p where (p.isDeleted IS NULL OR p.isDeleted = false)")
+    List<Project> findActiveProjects();
 
+    // 삭제된 프로젝트 조회
+    @Query("select p from Project p where p.isDeleted = true")
+    List<Project> findDeletedProjects();
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectService.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.project.service;
 
+import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.project.dto.request.*;
 import org.etmetmy.bn_server.domain.project.dto.response.*;
 import org.etmetmy.bn_server.domain.project.dto.request.ProjectCreateRequest;
@@ -38,4 +39,7 @@ public interface ProjectService {
     // 프로젝트 진행단계 수정
     ProjectStageUpdateResponse updateProjectStage(Long projectId, ProjectStageUpdateRequest request, Long currentUserId);
     ProjectDetailResponse getProjectDetail(Long projectId);
+
+    // (휴지통 페이지) 삭제된 프로젝트 조회
+    List<DeletedProjectResponse> getDeletedProjectList(Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.project.service;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.etmetmy.bn_server.domain.file.entity.File;
@@ -23,6 +24,7 @@ import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.domain.project.repository.ProjectCheckListRepository;
 import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
+import org.etmetmy.bn_server.domain.user.entity.Role;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.domain.user.repository.UserRepository;
 import org.etmetmy.bn_server.exception.custom.InvalidInputException;
@@ -30,6 +32,7 @@ import org.etmetmy.bn_server.exception.custom.UserNotFoundException;
 import org.etmetmy.bn_server.exception.code.ErrorCode;
 import org.etmetmy.bn_server.exception.custom.BusinessException;
 import org.etmetmy.bn_server.exception.custom.ProjectNotFoundException;
+import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -450,5 +453,18 @@ public class ProjectServiceImpl implements ProjectService{
                 .orElseThrow(ProjectNotFoundException::new);
 
         return ProjectDetailResponse.Converter.from(project);
+    }
+
+    // (휴지통 페이지) 삭제된 프로젝트 목록 조회
+    public List<DeletedProjectResponse> getDeletedProjectList(Long loginUserId)
+    {
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new BusinessException(ErrorCode.DELETED_PROJECT_ACCESS_DENIED);
+        }
+        List<Project> projects = projectRepository.findDeletedProjects();
+
+        return DeletedProjectResponse.Converter.from(projects);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -36,7 +36,7 @@ public enum ErrorCode {
     PROJECT_CANNOT_DELETE(400, "P004", "진행 중인 프로젝트는 삭제할 수 없습니다."),
     PROJECT_NAME_DUPLICATE(409, "P005", "중복된 프로젝트명입니다."),
     PROJECT_AND_USER_NOT_FOUND(404,"PU001", "사용자가 해당 프로젝트에 속해있지 않습니다."),
-
+    DELETED_PROJECT_ACCESS_DENIED(403, "P006", "삭제된 프로젝트 접근 권한이 없습니다."),
 
     // 승인 관련 에러
     REQUEST_PENDING_NOT_FOUND(404,"R001","해당 게시글에 승인 대기 중인 요청이 없습니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
- 프로젝트 휴지통(삭제된 프로젝트 목록) 조회 기능 구현 
- 추가 수정 : 대시보드에서 프로젝트 목록 조회 시 삭제된 프로젝트 제외

 ### 1. 삭제된 프로젝트 목록 조회 API 추가

  - GET /api/v1/admin/projects/trash 엔드포인트 추가
  - ADMIN 권한만 접근 가능하도록 권한 체크 로직 구현
  - DeletedProjectResponse DTO 추가

  ### 2. 프로젝트 Repository 쿼리 개선

  - findActiveProjects(): 삭제되지 않은 프로젝트 조회 (isDeleted IS NULL OR isDeleted = false)
  - findDeletedProjects(): 삭제된 프로젝트 조회 (isDeleted = true)

  ### 3. 대시보드 프로젝트 목록 조회 수정

  - 프로젝트 목록 조회 시 findActiveProjects()를 사용하여 삭제된 프로젝트 제외
  - 삭제 여부가 null인 기존 프로젝트도 정상 조회되도록 처리

  ### 4. 예외 처리 추가

  - DELETED_PROJECT_ACCESS_DENIED: 삭제된 프로젝트 접근 권한 없음 에러 코드 추가
<img width="1160" height="1410" alt="image" src="https://github.com/user-attachments/assets/0a253ade-96c2-4de1-a9cd-07c986c3bd4e" />
<img width="994" height="858" alt="image" src="https://github.com/user-attachments/assets/7b9dc126-04d5-498e-bc90-281cff650900" />
- DEVELOPER 일 때 접근 불가
<img width="1710" height="810" alt="image" src="https://github.com/user-attachments/assets/5bbf02e3-7b15-4de1-8c32-b260ee81de7e" />


## 📎 Issue 114

<!-- closed #114 -->
