### PR TITLE
Feat/ 삭제된 프로젝트 복원 기능 구현

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectController.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.project.controller;
 
 import jakarta.servlet.http.HttpSession;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.project.dto.request.*;
 import org.etmetmy.bn_server.domain.project.dto.response.*;
@@ -166,6 +167,18 @@ public class ProjectController {
         Long loginUserId = SessionUtil.getLoginUserId(session);
         List<DeletedProjectResponse> response = projectService.getDeletedProjectList(loginUserId);
 
-        return CommonResponse.success("삭제된 프로젝트 목록 조회", response);
+        return CommonResponse.success("삭제된 프로젝트 목록 조회 성공", response);
+    }
+
+    //todo: 삭제된 프로젝트 복원
+    @PatchMapping("/trash/restore")
+    public CommonResponse<ProjectRestoreResponse> restoreDeletedProject(
+            HttpSession session,
+            @Valid @RequestBody ProjectRestoreRequest request)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        ProjectRestoreResponse response = projectService.restoreDeletedProject(loginUserId, request);
+
+        return CommonResponse.success("삭제된 프로젝트 복원 성공", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/request/ProjectRestoreRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/request/ProjectRestoreRequest.java
@@ -1,0 +1,17 @@
+package org.etmetmy.bn_server.domain.project.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProjectRestoreRequest {
+
+    @JsonProperty("project_ids")
+    private List<Long> projectIds;
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectRestoreResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectRestoreResponse.java
@@ -1,0 +1,34 @@
+package org.etmetmy.bn_server.domain.project.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.project.entity.Project;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectRestoreResponse {
+
+    @JsonProperty("restored_count")
+    private Long restoredCount;
+
+    @JsonProperty("restored_ids")
+    private List<Long> restoredIds;
+
+    public static class Converter {
+        public static ProjectRestoreResponse from(List<Project> projects) {
+
+            return ProjectRestoreResponse.builder()
+                    .restoredCount((long)projects.size()).restoredIds(
+                            projects.stream()
+                                    .map(Project::getId).toList())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectRestoreResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectRestoreResponse.java
@@ -25,9 +25,8 @@ public class ProjectRestoreResponse {
         public static ProjectRestoreResponse from(List<Project> projects) {
 
             return ProjectRestoreResponse.builder()
-                    .restoredCount((long)projects.size()).restoredIds(
-                            projects.stream()
-                                    .map(Project::getId).toList())
+                    .restoredCount((long)projects.size())
+                    .restoredIds(projects.stream().map(Project::getId).toList())
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -9,7 +9,6 @@ import org.etmetmy.bn_server.domain.company.entity.Company;
 import org.etmetmy.bn_server.domain.memo.entity.Memo;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
-import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -63,5 +63,6 @@ public class Project extends BaseEntity {
 
     public void restore() {
         isDeleted = false;
+        deletedAt = null;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -9,6 +9,7 @@ import org.etmetmy.bn_server.domain.company.entity.Company;
 import org.etmetmy.bn_server.domain.memo.entity.Memo;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -53,10 +54,14 @@ public class Project extends BaseEntity {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<Memo> memo;
 
-    //프로젝트 삭제(휴지통으로 이동)을 위한 엔티티 추가
-    @Column(name = "is_deleted")
+    @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+
+    public void restore() {
+        isDeleted = false;
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectService.java
@@ -42,4 +42,7 @@ public interface ProjectService {
 
     // (휴지통 페이지) 삭제된 프로젝트 조회
     List<DeletedProjectResponse> getDeletedProjectList(Long loginUserId);
+
+    // 삭제된 프로젝트 복원
+    ProjectRestoreResponse restoreDeletedProject(Long loginUserId, ProjectRestoreRequest request);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -456,6 +456,8 @@ public class ProjectServiceImpl implements ProjectService{
     }
 
     // (휴지통 페이지) 삭제된 프로젝트 목록 조회
+    @Override
+    @Transactional(readOnly = true)
     public List<DeletedProjectResponse> getDeletedProjectList(Long loginUserId)
     {
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
@@ -466,5 +468,29 @@ public class ProjectServiceImpl implements ProjectService{
         List<Project> projects = projectRepository.findDeletedProjects();
 
         return DeletedProjectResponse.Converter.from(projects);
+    }
+
+    // 삭제된 프로젝트 복원
+    @Override
+    @Transactional
+    public ProjectRestoreResponse restoreDeletedProject(Long loginUserId, ProjectRestoreRequest request){
+
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new BusinessException(ErrorCode.DELETED_PROJECT_ACCESS_DENIED);
+        }
+        List<Long> projectIds = request.getProjectIds();
+        List<Project> projects = projectRepository.findAllById(projectIds);
+
+        projects.forEach(project -> {
+            if (!project.getIsDeleted()) {
+                throw new BusinessException(ErrorCode.PROJECT_NOT_DELETED);
+            }
+            project.restore();
+        });
+
+        projectRepository.saveAll(projects);
+        return ProjectRestoreResponse.Converter.from(projects);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -475,14 +475,22 @@ public class ProjectServiceImpl implements ProjectService{
     @Transactional
     public ProjectRestoreResponse restoreDeletedProject(Long loginUserId, ProjectRestoreRequest request){
 
+        // 권한 검증
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
-
         if (user.getRole() != Role.ADMIN) {
             throw new BusinessException(ErrorCode.DELETED_PROJECT_ACCESS_DENIED);
         }
+
+        // 요청한 프로젝트 ID 조회
         List<Long> projectIds = request.getProjectIds();
         List<Project> projects = projectRepository.findAllById(projectIds);
 
+        // 1. 존재 개수 비교
+        if (projects.size() != projectIds.size()) {
+            throw new ProjectNotFoundException("존재하지 않는 프로젝트가 포함되어 있습니다.");
+        }
+
+        // 2. 삭제 여부 체크
         projects.forEach(project -> {
             if (!project.getIsDeleted()) {
                 throw new BusinessException(ErrorCode.PROJECT_NOT_DELETED);

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     PROJECT_NAME_DUPLICATE(409, "P005", "중복된 프로젝트명입니다."),
     PROJECT_AND_USER_NOT_FOUND(404,"PU001", "사용자가 해당 프로젝트에 속해있지 않습니다."),
     DELETED_PROJECT_ACCESS_DENIED(403, "P006", "삭제된 프로젝트 접근 권한이 없습니다."),
+    PROJECT_NOT_DELETED(400, "P007", "이미 삭제되지 않은 프로젝트입니다."),
 
     // 승인 관련 에러
     REQUEST_PENDING_NOT_FOUND(404,"R001","해당 게시글에 승인 대기 중인 요청이 없습니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
- 관리자가 휴지통에 있는 삭제된 프로젝트를 복원할 수 있는 기능을 구현했습니다.

### 구현 기능

  - 권한 검증: ADMIN 역할만 복원 가능
  - 존재 여부 검증: 요청한 프로젝트 ID가 DB에 존재하는지 확인
    - 존재하지 않는 경우 ProjectNotFoundException 발생
  - 삭제 상태 검증: 삭제된 상태(isDeleted = true)인 프로젝트만 복원 가능
    - 삭제되지 않은 프로젝트 복원 시도 시 BusinessException 발생
  - 여러 프로젝트 일괄 복원 지원

### restore() 메서드 추가
- `isDeleted`를 false로, `deletedAt`을 null로 변경
  
### 에러 처리

  - PROJECT_NOT_DELETED: 삭제되지 않은 프로젝트 복원 시도 시 반환
  - ProjectNotFoundException: 존재하지 않는 프로젝트 ID 포함 시 반환
  - DELETED_PROJECT_ACCESS_DENIED: ADMIN이 아닌 사용자의 접근 시도 시 반환
 
#### - 에러 결과
<img width="1708" height="950" alt="image" src="https://github.com/user-attachments/assets/2d145f1a-e2c2-4e9d-8b61-a4fc864843d3" />
<img width="850" height="472" alt="image" src="https://github.com/user-attachments/assets/d7990d96-fb42-4687-923d-bd49d49e40df" />

#### - 정상 결과

<img width="1696" height="952" alt="image" src="https://github.com/user-attachments/assets/2ee44751-881e-4f7d-9c24-bae663a6f196" />

## 📎 Issue 118

<!-- closed #118  -->
