### PR TITLE
refactor/ Cascade Delete 매핑 연결

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/comment/entity/Comment.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/entity/Comment.java
@@ -5,9 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.etmetmy.bn_server.domain.file.entity.File;
+import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "comment")
@@ -38,4 +43,12 @@ public class Comment extends BaseEntity {
 
     @Column(name = "comment_id2")
     private Long commentId2;
+
+    //파일 목록
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<File> files = new ArrayList<>();
+
+    //링크 목록
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Link> links = new ArrayList<>();
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/entity/Post.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/entity/Post.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.post.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.project.entity.Project;
@@ -62,6 +63,10 @@ public class Post extends BaseEntity {
     //링크 목록
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Link> links = new ArrayList<>();
+
+    //댓글 목록
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
 
     // 게시글 업데이트 메서드

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/entity/ProjectDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/entity/ProjectDTO.java
@@ -29,8 +29,8 @@ public class ProjectDTO {
     public static class Converter {
 
         public static ProjectResponse toResponse(Project project, List<ProjectMember> members){
-            Memo memo = (project.getMemo() != null && !project.getMemo().isEmpty())
-                    ? project.getMemo().get(0)
+            Memo memo = (project.getMemos() != null && !project.getMemos().isEmpty())
+                    ? project.getMemos().get(0)
                     : null;
 
             // ProjectMember에서 userId만 추출하여 List<Long>으로 변환

--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectResponse.java
@@ -35,8 +35,8 @@ public class ProjectResponse {
 
     public static class Converter {
         public static ProjectResponse from(Project project,  List<ProjectMember> members) {
-            Memo memo = (project.getMemo() != null && !project.getMemo().isEmpty())
-                    ? project.getMemo().get(0)
+            Memo memo = (project.getMemos() != null && !project.getMemos().isEmpty())
+                    ? project.getMemos().get(0)
                     : null;
 
             List<Long> memberUserIds = members == null ? List.of()

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.etmetmy.bn_server.domain.company.entity.Company;
 import org.etmetmy.bn_server.domain.memo.entity.Memo;
+import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -50,8 +52,14 @@ public class Project extends BaseEntity {
     @JoinColumn(name = "stage_id")
     private Stage stage;
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
-    private List<Memo> memo;
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectCheckList> projectCheckLists = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Memo> memos = new ArrayList<>();
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/ProjectCheckList.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/ProjectCheckList.java
@@ -6,8 +6,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.etmetmy.bn_server.domain.checkList.entity.CheckList;
+import org.etmetmy.bn_server.domain.file.entity.File;
+import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "projectchecklist")
@@ -36,6 +41,14 @@ public class ProjectCheckList extends BaseEntity {
 
     @Column(name = "checked")
     private Boolean checked;
+
+    //파일 목록
+    @OneToMany(mappedBy = "projectCheckList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<File> files = new ArrayList<>();
+
+    //링크 목록
+    @OneToMany(mappedBy = "projectCheckList", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Link> links = new ArrayList<>();
 
     @PrePersist
     protected void onCreateCheckList() {


### PR DESCRIPTION
## 📄 작업 내용 요약

```
Project 삭제
    ├─ Post (자동 삭제)
    │   ├─ Comment (Post 삭제로 연쇄)
    │   │   ├─ File (Comment 삭제로 연쇄) ✅ 추가됨
    │   │   └─ Link (Comment 삭제로 연쇄) ✅ 추가됨
    │   ├─ File (Post 삭제로 연쇄)
    │   └─ Link (Post 삭제로 연쇄)
    ├─ ProjectCheckList (자동 삭제)
    │   ├─ File (ProjectCheckList 삭제로 연쇄) ✅ 추가됨
    │   └─ Link (ProjectCheckList 삭제로 연쇄) ✅ 추가됨
    └─ Memo (자동 삭제)
```
```
Comment 삭제
    ├─ File (자동 삭제) ✅ 추가됨
    └─ Link (자동 삭제) ✅ 추가됨
```
```
Post 삭제
    ├─ Comment (자동 삭제)
    │   ├─ File (Comment 삭제로 연쇄)
    │   └─ Link (Comment 삭제로 연쇄)
    ├─ File (자동 삭제)
    └─ Link (자동 삭제)
```
```
 ProjectCheckList 삭제
    ├─ File (자동 삭제) ✅ 추가됨
    └─ Link (자동 삭제) ✅ 추가됨
```

## 컬렉션 필드 초기화 이유

  `@OneToMany` 관계의 컬렉션을 `new ArrayList<>()`로 초기화

  - **NullPointerException 방지**: 새 엔티티 생성 시 즉시 사용 가능
  - **코드 간결성**: null 체크 불필요
  - **JPA Best Practice**: Hibernate 권장사항 준수
  - **일관성**: 신규/로딩된 엔티티 모두 동일하게 동작

  예시:
  ```java
  Project project = Project.builder().build();
  project.getPosts().add(newPost);  // NPE 없이 바로 사용 가능

  참고: @SuperBuilder + @NoArgsConstructor 사용으로 필드 초기화가 적절히 작동합니다.
  ```

## 📎 Issue 123

<!-- closed #123 -->
