### PR TITLE
Refactor/ 중복된 메서드 추출

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -7,9 +7,6 @@ import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 
-import static org.etmetmy.bn_server.domain.file.service.FileServiceImpl.extractFileName;
-import static org.etmetmy.bn_server.domain.file.service.FileServiceImpl.extractFileType;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -20,9 +17,8 @@ public class FileCreateRequest {
 
 
     public static class Converter {
-        /**
-         * File 엔티티 생성
-         */
+
+        // File 엔티티 생성
         public static File toEntity(String fileUrl, Long fileSize, Post post, Long uploadedBy) {
             return File.builder()
                     .post(post)
@@ -33,6 +29,18 @@ public class FileCreateRequest {
                     .uploadedBy(uploadedBy)
                     .isDeleted(false)
                     .build();
+        }
+
+        // URL 에서 파일명 추출
+        public static String extractFileName(String url) {
+            int lastSlash = url.lastIndexOf('/');
+            return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
+        }
+
+        // URL 에서 파일 확장자 추출
+        public static String extractFileType(String url) {
+            int lastDot = url.lastIndexOf('.');
+            return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -23,12 +23,12 @@ public class FileCreateRequest {
         /**
          * File 엔티티 생성
          */
-        public static File toEntity(String fileUrl, Post post, Long uploadedBy) {
+        public static File toEntity(String fileUrl, Long fileSize, Post post, Long uploadedBy) {
             return File.builder()
                     .post(post)
                     .fileTitle(extractFileName(fileUrl))
                     .filePath(fileUrl)
-                    .fileSize(0L)
+                    .fileSize(fileSize)
                     .fileType(extractFileType(fileUrl))
                     .uploadedBy(uploadedBy)
                     .isDeleted(false)

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -1,8 +1,8 @@
 package org.etmetmy.bn_server.domain.file.service;
 
 import jakarta.servlet.http.HttpSession;
-import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.entity.File;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -20,4 +20,16 @@ public interface FileService {
 
     // 업로드 된 파일 삭제 (soft delete)
     void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
+
+    // S3 업로드 메서드
+    public String uploadToS3(MultipartFile file);
+
+    // 삭제에 필요한 key 반환
+    public String getKeyFromFileUrls(String fileUrl);
+
+    // S3와 DB 에서 파일 삭제
+    void deleteFilesFromS3AndDb(List<File> files);
+
+    // S3에서 파일 삭제
+    void deleteFilesFromS3(List<File> files);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -129,33 +129,10 @@ public class FileServiceImpl implements FileService {
                 throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
             }
         }
-
-        for (File file : files) {
-            try {
-                String fileUrl = file.getFilePath();
-                Long fileId = file.getFileId();
-
-                // S3 key 추출
-                String key = getKeyFromFileUrls(fileUrl);
-
-                // S3 삭제 요청
-                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                        .bucket(bucketName)
-                        .key(key)
-                        .build();
-
-                s3Client.deleteObject(deleteRequest);
-
-                // DB 레코드 삭제
-                fileRepository.deleteById(fileId);
-
-            } catch (Exception e) {
-                throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
-            }
-        }
+        deleteFilesFromS3AndDb(files);
     }
 
-    // 5. 업로드 된 파일 삭제 (soft delete)
+    // 4. 업로드 된 파일 삭제 (soft delete)
     @Override
     @Transactional
     public void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId){
@@ -187,20 +164,21 @@ public class FileServiceImpl implements FileService {
         fileRepository.save(file);
     }
 
-    // URL 에서 파일명 추출
+    // 5. URL 에서 파일명 추출
     public static String extractFileName(String url) {
         int lastSlash = url.lastIndexOf('/');
         return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
     }
 
-    // URL 에서 파일 확장자 추출
+    // 6. URL 에서 파일 확장자 추출
     public static String extractFileType(String url) {
         int lastDot = url.lastIndexOf('.');
         return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
     }
 
-    // S3 업로드 메서드
-    private String uploadToS3(MultipartFile file) {
+    // 7. S3 업로드 메서드
+    @Override
+    public String uploadToS3(MultipartFile file) {
 
         String originalFilename = file.getOriginalFilename();
         String s3FileName = UUID.randomUUID() + "_" + originalFilename;
@@ -224,8 +202,9 @@ public class FileServiceImpl implements FileService {
                 .toString();
     }
 
-    // 삭제에 필요한 key 반환
-    private String getKeyFromFileUrls(String fileUrl) {
+    // 8. 삭제에 필요한 key 반환
+    @Override
+    public String getKeyFromFileUrls(String fileUrl) {
         try{
             URL url = new URI(fileUrl).toURL();
             String decodedKey = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
@@ -235,6 +214,59 @@ public class FileServiceImpl implements FileService {
         }
         catch (Exception e){
             throw new BusinessException(ErrorCode.INVALID_URL_FORMAT);
+        }
+    }
+
+    // S3에서 파일 삭제 후 DB 레코드도 삭제
+    @Override
+    public void deleteFilesFromS3AndDb(List<File> files) {
+        for (File file : files) {
+            try {
+                String fileUrl = file.getFilePath();
+                Long fileId = file.getFileId();
+
+                // S3 key 추출
+                String key = getKeyFromFileUrls(fileUrl);
+
+                // S3 삭제 요청
+                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build();
+
+                s3Client.deleteObject(deleteRequest);
+
+                // DB 레코드 삭제
+                fileRepository.deleteById(fileId);
+
+            } catch (Exception e) {
+                throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+            }
+        }
+    }
+
+    // S3에서 파일 삭제
+    @Override
+    public void deleteFilesFromS3(List<File> files) {
+        for (File file : files) {
+            try {
+                String fileUrl = file.getFilePath();
+                Long fileId = file.getFileId();
+
+                // S3 key 추출
+                String key = getKeyFromFileUrls(fileUrl);
+
+                // S3 삭제 요청
+                DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build();
+
+                s3Client.deleteObject(deleteRequest);
+
+            } catch (Exception e) {
+                throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+            }
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -249,15 +249,4 @@ public class FileServiceImpl implements FileService {
             }
         }
     }
-    // 9. URL 에서 파일명 추출
-    public static String extractFileName(String url) {
-        int lastSlash = url.lastIndexOf('/');
-        return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
-    }
-
-    // 10. URL 에서 파일 확장자 추출
-    public static String extractFileType(String url) {
-        int lastDot = url.lastIndexOf('.');
-        return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.file.service;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
@@ -89,21 +90,12 @@ public class FileServiceImpl implements FileService {
             // S3 업로드
             String fileUrl = uploadToS3(file);
 
-            // 파일명, 확장자 추출
-            String savedFileName = extractFileName(fileUrl);
-            String fileType = extractFileType(fileUrl);
+            // DTO Converter를 통한 엔티티 생성
+            File fileEntity = FileCreateRequest.Converter.toEntity(
+                    fileUrl, file.getSize(), post, post.getUser().getId());
 
             // DB에 저장
-            File saved = fileRepository.save(File.builder()
-                    .fileTitle(savedFileName) // 원본 파일명
-                    .filePath(fileUrl)
-                    .fileSize(file.getSize())
-                    .fileType(fileType)
-                    .post(post)
-                    .uploadedBy(post.getUser().getId())
-                    .isDeleted(false)
-                    .build());
-
+            File saved = fileRepository.save(fileEntity);
             savedFiles.add(saved);
         }
         return ActiveFileListDTO.Converter.from(savedFiles);
@@ -164,19 +156,7 @@ public class FileServiceImpl implements FileService {
         fileRepository.save(file);
     }
 
-    // 5. URL 에서 파일명 추출
-    public static String extractFileName(String url) {
-        int lastSlash = url.lastIndexOf('/');
-        return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
-    }
-
-    // 6. URL 에서 파일 확장자 추출
-    public static String extractFileType(String url) {
-        int lastDot = url.lastIndexOf('.');
-        return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
-    }
-
-    // 7. S3 업로드 메서드
+    // 5. S3 업로드 메서드
     @Override
     public String uploadToS3(MultipartFile file) {
 
@@ -202,7 +182,7 @@ public class FileServiceImpl implements FileService {
                 .toString();
     }
 
-    // 8. 삭제에 필요한 key 반환
+    // 6. 삭제에 필요한 key 반환
     @Override
     public String getKeyFromFileUrls(String fileUrl) {
         try{
@@ -217,7 +197,7 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // S3에서 파일 삭제 후 DB 레코드도 삭제
+    // 7. S3에서 파일 삭제 후 DB 레코드도 삭제
     @Override
     public void deleteFilesFromS3AndDb(List<File> files) {
         for (File file : files) {
@@ -245,7 +225,7 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // S3에서 파일 삭제
+    // 8. S3에서 파일 삭제
     @Override
     public void deleteFilesFromS3(List<File> files) {
         for (File file : files) {
@@ -268,5 +248,16 @@ public class FileServiceImpl implements FileService {
                 throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
             }
         }
+    }
+    // 9. URL 에서 파일명 추출
+    public static String extractFileName(String url) {
+        int lastSlash = url.lastIndexOf('/');
+        return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
+    }
+
+    // 10. URL 에서 파일 확장자 추출
+    public static String extractFileType(String url) {
+        int lastDot = url.lastIndexOf('.');
+        return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -86,4 +86,5 @@ public class PostCreateRequest {
                     .build();
         }
     }
+
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -30,11 +30,20 @@ public class PostCreateRequest {
     @NotNull(message = "단계 ID는 필수입니다.")
     private Long stageId;
 
-    // S3에 업로드된 임시 파일 URL 목록 (선택 사항)
-    private List<String> fileUrls;
+    // S3에 업로드된 파일 정보 목록 (선택 사항)
+    private List<FileInfo> fileInfos;
 
     // 링크 URL 목록 (선택 사항)
     private List<String> linkUrls;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class FileInfo {
+        private String fileUrl;
+        private Long fileSize;
+    }
 
     public static class Converter {
         public static Post toEntity(

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -117,9 +117,7 @@ public class PostServiceImpl implements PostService {
         return postRepository.findByProjectIdAndStageId(projectId, stageEntity.getId());
     }
 
-    /**
-     * 필터에 따라 게시글 조회
-     */
+    // 필터에 따라 게시글 조회
     private List<Post> getPostsByFilter(Long projectId, String filter) {
         return switch (filter.toLowerCase()) {
             case "all" -> postRepository.findAllByProjectId(projectId);
@@ -129,20 +127,15 @@ public class PostServiceImpl implements PostService {
         };
     }
 
-    /**
-     * 게시글 작성 API
-     */
+    // 게시글 작성
     @Override
     @Transactional
     public PostCreateResponse createPost(Long projectId, PostCreateRequest requestDto, Long loginUserId) {
 
         // 필요한 엔티티 조회
-        User user = userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(ProjectNotFoundException::new);
-        Stage stage = stageRepository.findById(requestDto.getStageId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
+        Stage stage = stageRepository.findById(requestDto.getStageId()).orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
 
         // Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
         PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
@@ -162,9 +155,14 @@ public class PostServiceImpl implements PostService {
 
         // 파일 처리
         List<File> savedFiles = new ArrayList<>();
-        if (requestDto.getFileUrls() != null && !requestDto.getFileUrls().isEmpty()) {
-            for (String fileUrl : requestDto.getFileUrls()) {
-                File file = FileCreateRequest.Converter.toEntity(fileUrl, savedPost, loginUserId);
+        if (requestDto.getFileInfos() != null && !requestDto.getFileInfos().isEmpty()) {
+            for (PostCreateRequest.FileInfo fileInfo : requestDto.getFileInfos()) {
+                File file = FileCreateRequest.Converter.toEntity(
+                        fileInfo.getFileUrl(),
+                        fileInfo.getFileSize(),
+                        savedPost,
+                        loginUserId
+                );
                 savedFiles.add(file);
             }
             fileRepository.saveAll(savedFiles);
@@ -189,14 +187,10 @@ public class PostServiceImpl implements PostService {
     public ReplyPostCreateResponse createReplyPost(Long projectId, PostCreateRequest requestDto, Long postId, Long loginUserId) {
 
         // 1. 필요한 엔티티 조회
-        User user = userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(ProjectNotFoundException::new);
-        Stage stage = stageRepository.findById(requestDto.getStageId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
-        Post post = postRepository.findById(postId)
-                .orElseThrow(BoardNotFoundException::new);
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
+        Stage stage = stageRepository.findById(requestDto.getStageId()).orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(BoardNotFoundException::new);
 
         // 2. Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
         PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
@@ -216,9 +210,14 @@ public class PostServiceImpl implements PostService {
 
         // 4. 파일 처리
         List<File> savedFiles = new ArrayList<>();
-        if (requestDto.getFileUrls() != null && !requestDto.getFileUrls().isEmpty()) {
-            for (String fileUrl : requestDto.getFileUrls()) {
-                File file = FileCreateRequest.Converter.toEntity(fileUrl, savedPost, loginUserId);
+        if (requestDto.getFileInfos() != null && !requestDto.getFileInfos().isEmpty()) {
+            for (PostCreateRequest.FileInfo fileInfo : requestDto.getFileInfos()) {
+                File file = FileCreateRequest.Converter.toEntity(
+                        fileInfo.getFileUrl(),
+                        fileInfo.getFileSize(),
+                        savedPost,
+                        loginUserId
+                );
                 savedFiles.add(file);
             }
             fileRepository.saveAll(savedFiles);


### PR DESCRIPTION
## 📄 작업 내용 요약

 ### 1. FileCreateRequest.Converter 개선
  - toEntity() 메서드에 fileSize 파라미터 추가
  - 파일명/확장자 추출 로직을 FileServiceImpl의 static 메서드(extractFileName, extractFileType)를 활용
  - 실제 파일 크기를 받아 엔티티에 저장하도록 수정

   ###  2. FileServiceImpl - 유틸리티 메서드 분리

  - extractFileName(), extractFileType() 메서드를 public static으로 유지
  - DTO에서 재사용 가능하도록 구조화

   ###  3. PostCreateRequest에 FileInfo 추가

  - 파일 URL과 크기를 함께 전달하기 위한 FileInfo 내부 클래스 추가
  - List<String> fileUrls → List<FileInfo> fileInfos로 변경

### 4. FileServiceImpl.postFiles() 리팩토링

  - File 엔티티 생성 로직을 DTO Converter로 위임
  - 서비스 계층의 책임을 축소하고 코드 간결화

### 5. PostServiceImpl 수정

  - createPost() 메서드: FileInfo를 사용하여 파일 크기 포함 저장
  - createReplyPost() 메서드: 동일하게 FileInfo 적용

  
## 📎 Issue 128

<!-- closed #128 -->
