### PR TITLE
Refactor/ 부모게시글, 자식게시글 엔드포인트 통합 및 임시파일 업로드 수정

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.service.FileService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -35,13 +36,13 @@ public class FileController {
 
     // 2. 임시 파일 업로드 API
     @PostMapping("/posts/files/temp")
-    public CommonResponse<List<ActiveFileListDTO>> postFiles(
+    public CommonResponse<List<TempFileListDTO>> postFiles(
             @PathVariable Long projectId,
             @RequestPart("files") List<MultipartFile> files,
             HttpSession session)
     {
         Long loginUserId = SessionUtil.getLoginUserId(session);
-        List<ActiveFileListDTO> response = fileService.postFiles(projectId, files, loginUserId);
+        List<TempFileListDTO> response = fileService.postFiles(projectId, files, loginUserId);
 
         return CommonResponse.success("파일 업로드 성공", response);
     }
@@ -66,4 +67,7 @@ public class FileController {
         Long loginUserId = SessionUtil.getLoginUserId(session);
         fileService.deletePostFiles(projectId, postId, fileId, loginUserId);
     }
+
+    // 5. 파일과 게시글 조회
+
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -34,19 +34,20 @@ public class FileController {
     }
 
     // 2. 임시 파일 업로드 API
-    @PostMapping("/posts/{postId}/files")
+    @PostMapping("/posts/files/temp")
     public CommonResponse<List<ActiveFileListDTO>> postFiles(
             @PathVariable Long projectId,
-            @PathVariable Long postId,
-            @RequestPart("files") List<MultipartFile> files)
+            @RequestPart("files") List<MultipartFile> files,
+            HttpSession session)
     {
-        List<ActiveFileListDTO> response = fileService.postFiles(projectId, postId, files);
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        List<ActiveFileListDTO> response = fileService.postFiles(projectId, files, loginUserId);
 
         return CommonResponse.success("파일 업로드 성공", response);
     }
 
     // 3. 임시 파일 삭제 API (hard delete)
-    @DeleteMapping("files")
+    @DeleteMapping("files/temp")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteTempFile(@PathVariable Long projectId, @RequestBody FileDeleteRequest request)
     {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -5,12 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.entity.File;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -20,47 +16,41 @@ public class FileCreateRequest {
 
     private String fileUrl;
 
-
     public static class Converter {
 
-        // 다중 File 엔티티 생성
-        public static List<File> toEntity(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy) {
-            return fileInfos.stream()
-                    .map(fileInfo -> File.builder()
-                            .post(post)
-                            .fileTitle(extractFileName(fileInfo.getFileUrl()))
-                            .filePath(fileInfo.getFileUrl())
-                            .fileSize(fileInfo.getFileSize())
-                            .fileType(extractFileType(fileInfo.getFileUrl()))
-                            .uploadedBy(uploadedBy)
-                            .isDeleted(false)
-                            .build())
-                    .collect(Collectors.toList());
-        }
-
-        // 단일 파일 엔티티 생성 (MultipartFile 기반)
+        // 임시 파일 엔티티 생성 (MultipartFile 기반)
         public static File toEntity(Post post, String fileUrl, MultipartFile file, Long uploadedBy) {
             return File.builder()
                     .post(post)
-                    .fileTitle(extractFileName(fileUrl))  // URL에서 파일명 추출
-                    .filePath(fileUrl)                     // S3 저장 경로
-                    .fileSize(file.getSize())              // 파일 크기
-                    .fileType(extractFileType(fileUrl))   // URL에서 확장자 추출
+                    .fileTitle(extractFileName(fileUrl))
+                    .filePath(fileUrl) // S3 저장 경로
+                    .fileSize(file.getSize())
+                    .fileType(extractFileType(fileUrl))
                     .uploadedBy(uploadedBy)
+                    .isTemp(true)
                     .isDeleted(false)
                     .build();
         }
 
         // URL 에서 파일명 추출
         public static String extractFileName(String url) {
-            int lastSlash = url.lastIndexOf('/');
-            return lastSlash >= 0 ? url.substring(lastSlash + 1) : "unknown";
+            if (url == null || url.isEmpty()) return "unknown";
+
+            // 1. 쿼리 제거
+            String path = url.split("\\?")[0];
+
+            // 2. 마지막 슬래시 이후 추출
+            int lastSlash = path.lastIndexOf('/');
+            return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
         }
 
         // URL 에서 파일 확장자 추출
         public static String extractFileType(String url) {
-            int lastDot = url.lastIndexOf('.');
-            return lastDot >= 0 ? url.substring(lastDot + 1).toLowerCase() : "unknown";
+            if (url == null || url.isEmpty()) return "unknown";
+
+            String path = url.split("\\?")[0]; // 쿼리 제거
+            int lastDot = path.lastIndexOf('.');
+            return lastDot >= 0 ? path.substring(lastDot + 1).toLowerCase() : "unknown";
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -5,7 +5,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.entity.File;
+import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -18,14 +23,29 @@ public class FileCreateRequest {
 
     public static class Converter {
 
-        // File 엔티티 생성
-        public static File toEntity(String fileUrl, Long fileSize, Post post, Long uploadedBy) {
+        // 다중 File 엔티티 생성
+        public static List<File> toEntity(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy) {
+            return fileInfos.stream()
+                    .map(fileInfo -> File.builder()
+                            .post(post)
+                            .fileTitle(extractFileName(fileInfo.getFileUrl()))
+                            .filePath(fileInfo.getFileUrl())
+                            .fileSize(fileInfo.getFileSize())
+                            .fileType(extractFileType(fileInfo.getFileUrl()))
+                            .uploadedBy(uploadedBy)
+                            .isDeleted(false)
+                            .build())
+                    .collect(Collectors.toList());
+        }
+
+        // 단일 파일 엔티티 생성 (MultipartFile 기반)
+        public static File toEntity(Post post, String fileUrl, MultipartFile file, Long uploadedBy) {
             return File.builder()
                     .post(post)
-                    .fileTitle(extractFileName(fileUrl))
-                    .filePath(fileUrl)
-                    .fileSize(fileSize)
-                    .fileType(extractFileType(fileUrl))
+                    .fileTitle(extractFileName(fileUrl))  // URL에서 파일명 추출
+                    .filePath(fileUrl)                     // S3 저장 경로
+                    .fileSize(file.getSize())              // 파일 크기
+                    .fileType(extractFileType(fileUrl))   // URL에서 확장자 추출
                     .uploadedBy(uploadedBy)
                     .isDeleted(false)
                     .build();

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
@@ -1,0 +1,53 @@
+package org.etmetmy.bn_server.domain.file.dto.response;
+
+/*
+임시파일 목록 DTO
+*/
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.file.entity.File;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TempFileListDTO {
+
+    private Long fileId;
+    private String fileTitle;
+    private String filePath;
+    private String fileType;
+    private Long fileSize;
+
+    private Long uploadUserId;
+    private LocalDateTime uploadedAt;
+
+    // Converter 클래스
+    public static class Converter {
+        public static TempFileListDTO from(File file) {
+            return TempFileListDTO.builder()
+                    .fileId(file.getFileId())
+                    .fileTitle(file.getFileTitle())
+                    .filePath(file.getFilePath())
+                    .fileType(file.getFileType())
+                    .fileSize(file.getFileSize())
+                    .uploadUserId(file.getUploadedBy())
+                    .uploadedAt(file.getCreatedAt())
+                    .build();
+        }
+
+        public static List<TempFileListDTO> from(List<File> files) {
+            return files.stream()
+                    .map(TempFileListDTO.Converter::from)
+                    .collect(Collectors.toList());
+        }
+    }
+
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/UploadedFileDto.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/UploadedFileDto.java
@@ -1,0 +1,34 @@
+package org.etmetmy.bn_server.domain.file.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UploadedFileDto {
+
+    @JsonProperty("fileId")
+    private Long fileId;
+
+    public static class Converter {
+        // 해당 게시글에 연결된 모든 파일의 ID만 들어있는 DTO 리스트
+        public static List<UploadedFileDto> from(Post post) {
+            if (post.getFiles() == null || post.getFiles().isEmpty())
+                return List.of();
+
+            return post.getFiles().stream()
+                    .map(file -> UploadedFileDto.builder()
+                            .fileId(file.getFileId())
+                            .build())
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -54,12 +54,11 @@ public class File extends BaseEntity {
     @Column(name = "uploaded_by", nullable = false)
     private Long uploadedBy;
 
+    @Column(name = "is_temp")
+    private Boolean isTemp = true;
+
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted = false;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
-    private Project project;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
@@ -67,10 +66,21 @@ public class File extends BaseEntity {
     @Column(name = "deleted_by")
     private Long deletedBy;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
 
     public void softDelete(Long deletedBy) {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = deletedBy;
+    }
+
+    // 임시 파일 상태 변경
+    public void attachToPost(Post post,Long uploadedBy) {
+        this.post = post;
+        this.isTemp = false;
+        this.uploadedBy = uploadedBy;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
@@ -27,4 +27,7 @@ public interface FileRepository extends JpaRepository<File, Long> {
            "AND f.isDeleted = false")
     List<File> findByProjectCheckListId(@Param("projectCheckListId") Long projectCheckListId);
 
+    @Query("select f from File f " +
+            "where f.post.postId = :postId and f.isDeleted = false")
+    List<File> findFilesByPostId(Long postId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -3,7 +3,6 @@ package org.etmetmy.bn_server.domain.file.service;
 import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,7 +14,7 @@ public interface FileService {
     List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session);
 
     // 임시 파일 업로드
-    List<ActiveFileListDTO> postFiles(Long projectId, Long postId, List<MultipartFile> files);
+    List<ActiveFileListDTO> postFiles(Long projectId, List<MultipartFile> files, Long uploadedBy);
 
     // 임시 업로드 파일 삭제 (hard delete)
     void deleteFile(Long projectId, List<Long> fileIds);
@@ -36,5 +35,6 @@ public interface FileService {
     void deleteFilesFromS3(List<File> files);
 
     // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
-    void saveFiles(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy);
+    void saveFiles(Post post, List<Long> fileIds, Long loginUserId);
 }
+

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -3,6 +3,8 @@ package org.etmetmy.bn_server.domain.file.service;
 import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
+import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -32,4 +34,7 @@ public interface FileService {
 
     // S3에서 파일 삭제
     void deleteFilesFromS3(List<File> files);
+
+    // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    void saveFiles(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.file.service;
 
 import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,7 +15,7 @@ public interface FileService {
     List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session);
 
     // 임시 파일 업로드
-    List<ActiveFileListDTO> postFiles(Long projectId, List<MultipartFile> files, Long uploadedBy);
+    List<TempFileListDTO> postFiles(Long projectId, List<MultipartFile> files, Long uploadedBy);
 
     // 임시 업로드 파일 삭제 (hard delete)
     void deleteFile(Long projectId, List<Long> fileIds);

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
 import org.etmetmy.bn_server.domain.post.entity.Post;
@@ -77,7 +78,7 @@ public class FileServiceImpl implements FileService {
     // 2. 임시 파일 업로드
     @Override
     @Transactional
-    public List<ActiveFileListDTO> postFiles(Long projectId, List<MultipartFile> files,Long uploadedBy) {
+    public List<TempFileListDTO> postFiles(Long projectId, List<MultipartFile> files,Long uploadedBy) {
 
         List<File> savedFiles = new ArrayList<>();
 
@@ -93,7 +94,7 @@ public class FileServiceImpl implements FileService {
             File saved = fileRepository.save(fileEntity);
             savedFiles.add(saved);
         }
-        return ActiveFileListDTO.Converter.from(savedFiles);
+        return TempFileListDTO.Converter.from(savedFiles);
     }
 
     // 3. 파일 삭제 (hard delete)
@@ -245,10 +246,12 @@ public class FileServiceImpl implements FileService {
 
     // 9. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
     @Override
+    @Transactional
     public void saveFiles(Post post, List<Long> fileIds, Long loginUserId) {
 
-        for (Long id : fileIds) {
-            if (id == null) return;
+        // fileIds가 null이거나 비어있으면 아무것도 하지 않음
+        if (fileIds == null || fileIds.isEmpty()) {
+            return;
         }
 
         // 1. DB 에서 임시 파일 조회
@@ -256,6 +259,11 @@ public class FileServiceImpl implements FileService {
                 .stream()
                 .filter(File::getIsTemp)
                 .toList();
+
+        // 임시 파일이 없으면 예외 발생 (요청한 파일 ID가 존재하지 않거나 이미 사용됨)
+        if (tempFiles.isEmpty()) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+        }
 
         // 2. 게시글과 연결 + 상태 변경
         for (File file : tempFiles) {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -5,8 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
+import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
+import org.etmetmy.bn_server.domain.link.entity.Link;
+import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
 import org.etmetmy.bn_server.domain.post.service.PostServiceImpl;
@@ -91,8 +95,7 @@ public class FileServiceImpl implements FileService {
             String fileUrl = uploadToS3(file);
 
             // DTO Converter를 통한 엔티티 생성
-            File fileEntity = FileCreateRequest.Converter.toEntity(
-                    fileUrl, file.getSize(), post, post.getUser().getId());
+            File fileEntity = FileCreateRequest.Converter.toEntity(post, fileUrl, file, post.getUser().getId());
 
             // DB에 저장
             File saved = fileRepository.save(fileEntity);
@@ -248,5 +251,14 @@ public class FileServiceImpl implements FileService {
                 throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
             }
         }
+    }
+
+    // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    public void saveFiles(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy){
+        if (fileInfos == null || fileInfos.isEmpty()) {
+            return;
+        }
+        List<File> newFiles = FileCreateRequest.Converter.toEntity(post, fileInfos, uploadedBy);
+        fileRepository.saveAll(newFiles);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -3,14 +3,9 @@ package org.etmetmy.bn_server.domain.file.service;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
-import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
-import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
-import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
-import org.etmetmy.bn_server.domain.link.entity.Link;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
 import org.etmetmy.bn_server.domain.post.service.PostServiceImpl;
@@ -57,7 +52,7 @@ public class FileServiceImpl implements FileService {
 
     // 1. 프로젝트별 파일 목록 조회
     @Override
-    public List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session){
+    public List<ActiveFileListDTO> findAllByProjectId(Long projectId, HttpSession session) {
 
         // 1. 로그인 사용자 확인
         Long loginUserId = SessionUtil.getLoginUserId(session);
@@ -82,22 +77,19 @@ public class FileServiceImpl implements FileService {
     // 2. 임시 파일 업로드
     @Override
     @Transactional
-    public List<ActiveFileListDTO> postFiles(Long projectId, Long postId, List<MultipartFile> files){
-
-        Post post = postRepository.findById(postId)
-                .orElseThrow(BoardNotFoundException::new);
+    public List<ActiveFileListDTO> postFiles(Long projectId, List<MultipartFile> files,Long uploadedBy) {
 
         List<File> savedFiles = new ArrayList<>();
 
         for (MultipartFile file : files) {
 
-            // S3 업로드
+            // 1. S3 업로드
             String fileUrl = uploadToS3(file);
 
-            // DTO Converter를 통한 엔티티 생성
-            File fileEntity = FileCreateRequest.Converter.toEntity(post, fileUrl, file, post.getUser().getId());
+            // 2. 임시 파일 엔티티 생성 (post = null, isTemp = true)
+            File fileEntity = FileCreateRequest.Converter.toEntity(null, fileUrl, file, uploadedBy);
 
-            // DB에 저장
+            // 3. DB에 저장
             File saved = fileRepository.save(fileEntity);
             savedFiles.add(saved);
         }
@@ -107,7 +99,7 @@ public class FileServiceImpl implements FileService {
     // 3. 파일 삭제 (hard delete)
     @Override
     @Transactional
-    public void deleteFile(Long projectId, List<Long> fileIds){
+    public void deleteFile(Long projectId, List<Long> fileIds) {
 
         List<File> files = fileRepository.findAllById(fileIds);
 
@@ -130,7 +122,7 @@ public class FileServiceImpl implements FileService {
     // 4. 업로드 된 파일 삭제 (soft delete)
     @Override
     @Transactional
-    public void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId){
+    public void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId) {
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
@@ -166,7 +158,7 @@ public class FileServiceImpl implements FileService {
         String originalFilename = file.getOriginalFilename();
         String s3FileName = UUID.randomUUID() + "_" + originalFilename;
 
-        try(InputStream is = file.getInputStream()){
+        try (InputStream is = file.getInputStream()) {
 
             PutObjectRequest req = PutObjectRequest.builder()
                     .bucket(bucketName)
@@ -176,9 +168,8 @@ public class FileServiceImpl implements FileService {
                     .contentLength(file.getSize())
                     .build();
 
-            s3Client.putObject(req, RequestBody.fromInputStream(is,file.getSize()));
-        }
-        catch (Exception e){
+            s3Client.putObject(req, RequestBody.fromInputStream(is, file.getSize()));
+        } catch (Exception e) {
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
         return s3Client.utilities().getUrl(url -> url.bucket(bucketName).key(s3FileName))
@@ -188,14 +179,13 @@ public class FileServiceImpl implements FileService {
     // 6. 삭제에 필요한 key 반환
     @Override
     public String getKeyFromFileUrls(String fileUrl) {
-        try{
+        try {
             URL url = new URI(fileUrl).toURL();
             String decodedKey = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8);
 
             //경로 앞에 '/' 제거 후 반환
             return decodedKey.substring(1);
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             throw new BusinessException(ErrorCode.INVALID_URL_FORMAT);
         }
     }
@@ -253,12 +243,26 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
-    public void saveFiles(Post post, List<PostCreateRequest.FileInfo> fileInfos, Long uploadedBy){
-        if (fileInfos == null || fileInfos.isEmpty()) {
-            return;
+    // 9. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    @Override
+    public void saveFiles(Post post, List<Long> fileIds, Long loginUserId) {
+
+        for (Long id : fileIds) {
+            if (id == null) return;
         }
-        List<File> newFiles = FileCreateRequest.Converter.toEntity(post, fileInfos, uploadedBy);
-        fileRepository.saveAll(newFiles);
+
+        // 1. DB 에서 임시 파일 조회
+        List<File> tempFiles = fileRepository.findAllById(fileIds)
+                .stream()
+                .filter(File::getIsTemp)
+                .toList();
+
+        // 2. 게시글과 연결 + 상태 변경
+        for (File file : tempFiles) {
+            file.attachToPost(post, loginUserId);
+        }
+
+        // 3. DB 저장
+        fileRepository.saveAll(tempFiles);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkCreateRequest.java
@@ -7,6 +7,9 @@ import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,16 +19,26 @@ public class LinkCreateRequest {
     private String linkUrl;
 
     public static class Converter {
-        /**
-         * Link 엔티티 생성 (Post용)
-         */
-        public static Link toEntity(String linkUrl, Post post, Long uploadedBy) {
+
+        // Link 엔티티 생성 (post용)
+        public static Link toEntity(Post post, String url, Long uploadedBy) {
             return Link.builder()
                     .post(post)
-                    .linkUrl(linkUrl)
+                    .linkUrl(url)
                     .uploadedBy(uploadedBy)
                     .isDeleted(false)
                     .build();
+        }
+
+        public static List<Link> toEntity(Post post, List<String> linkUrls, Long uploadedBy) {
+            return linkUrls.stream()
+                    .map(url -> Link.builder()
+                            .post(post)
+                            .linkUrl(url)
+                            .uploadedBy(uploadedBy)
+                            .isDeleted(false)
+                            .build())
+                    .collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkInfoDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkInfoDTO.java
@@ -19,59 +19,22 @@ import java.util.List;
 @Builder
 public class LinkInfoDTO {
 
-    @JsonProperty("linkId")
-    private Long linkId;
-
     @JsonProperty("linkUrl")
     private String linkUrl;
 
-    /**
-     * Link 엔티티 리스트를 LinkInfo DTO 리스트로 변환
-     * 삭제된 링크는 제외
-     */
+
     public static class Converter {
+
         public static List<LinkInfoDTO> from(List<Link> links) {
-
-            // 1. links가 null 이면 빈 리스트 반환
-            if (links == null) {
-                return new ArrayList<>();
+            if (links == null || links.isEmpty()) {
+                return List.of();
             }
 
-            // 2. 변환된 LinkInfo를 담을 리스트 생성
-            List<LinkInfoDTO> linkInfos = new ArrayList<>();
-
-            // 3. 각 Link를 순회하면서 LinkInfo로 변환
-            for (Link link : links) {
-                // 삭제된 링크는 건너뛰기
-                if (link.getIsDeleted()) {
-                    continue;
-                }
-
-                // Link 엔티티의 정보를 LinkInfo DTO로 변환
-                linkInfos.add(LinkInfoDTO.builder()
-                        .linkId(link.getLinkId())
-                        .linkUrl(link.getLinkUrl())
-                        .build());
-            }
-            return linkInfos;
-        }
-
-        /**
-         * Link URL 문자열 리스트를 LinkInfo DTO 리스트로 변환
-         * (간단한 URL 리스트만 있을 경우)
-         */
-        public static List<String> toUrlList(List<Link> links) {
-            if (links == null) {
-                return new ArrayList<>();
-            }
-
-            List<String> urlList = new ArrayList<>();
-            for (Link link : links) {
-                if (!link.getIsDeleted() && link.getPost() != null) {
-                    urlList.add(link.getLinkUrl());
-                }
-            }
-            return urlList;
+            return links.stream()
+                    .map(link -> LinkInfoDTO.builder()
+                            .linkUrl(link.getLinkUrl())
+                            .build())
+                    .toList();
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/repository/LinkRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/repository/LinkRepository.java
@@ -2,7 +2,6 @@ package org.etmetmy.bn_server.domain.link.repository;
 
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.post.entity.Post;
-import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +22,8 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
            "WHERE l.projectCheckList.projectCheckListId = :projectCheckListId " +
            "AND l.isDeleted = false")
     List<Link> findByProjectCheckListId(@Param("projectCheckListId") Long projectCheckListId);
+
+    @Query("select f from Link f " +
+            "where f.post.postId = :postId")
+    List<Link> findLinksByPostId(Long postId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
@@ -1,0 +1,11 @@
+package org.etmetmy.bn_server.domain.link.service;
+
+import org.etmetmy.bn_server.domain.post.entity.Post;
+
+import java.util.List;
+
+public interface LinkService {
+
+    // 링크 저장
+    public void saveLinks(Post post, List<String> linkUrls, Long uploadedBy);
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface LinkService {
 
-    // 링크 저장
+    // 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 게시글에 한 번에 저장
     public void saveLinks(Post post, List<String> linkUrls, Long uploadedBy);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
@@ -1,0 +1,29 @@
+package org.etmetmy.bn_server.domain.link.service;
+
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
+import org.etmetmy.bn_server.domain.link.entity.Link;
+import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LinkServiceImpl implements LinkService {
+
+    private final LinkRepository linkRepository;
+
+    // 링크 저장
+    @Transactional
+    public void saveLinks(Post post, List<String> linkUrls, Long uploadedBy) {
+
+        if (linkUrls == null || linkUrls.isEmpty()) {
+            return;
+        }
+        List<Link> newLinks = LinkCreateRequest.Converter.toEntity(post, linkUrls, uploadedBy);
+        linkRepository.saveAll(newLinks);
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
@@ -16,7 +16,7 @@ public class LinkServiceImpl implements LinkService {
 
     private final LinkRepository linkRepository;
 
-    // 링크 저장
+    // 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 게시글에 한 번에 저장
     @Transactional
     public void saveLinks(Post post, List<String> linkUrls, Long uploadedBy) {
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -3,10 +3,8 @@ package org.etmetmy.bn_server.domain.post.controller;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.etmetmy.bn_server.domain.activityLog.aop.ActivityLogger;
 import org.etmetmy.bn_server.domain.post.dto.request.PostApprovalRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
@@ -39,7 +37,7 @@ public class PostController {
         return CommonResponse.success("게시글 작성 성공", response);
     }
 
-    // todo: 게시글 상세 조회
+    // todo: 게시글 상세 조회 API
     @GetMapping("/posts/{postId}")
     public CommonResponse<PostDetailResponse> getPostDetail(
             @PathVariable Long postId
@@ -62,7 +60,7 @@ public class PostController {
 
 
     // todo: 게시글 거절 API
-    @PatchMapping("/{postId}/reject")
+    @PatchMapping("posts/{postId}/reject")
     public ResponseEntity<CommonResponse<Object>> rejectPost(
             @PathVariable Long postId,
             @RequestBody @Valid PostApprovalRequest request

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -28,13 +28,13 @@ public class PostController {
 
     // todo: 부모 게시글, 자식 게시글 작성 API
     @PostMapping("/{projectId}/posts")
-    public CommonResponse<?> createPost(
+    public CommonResponse<PostCreateResponse> createPost(
             @PathVariable Long projectId,
             @Valid @RequestBody PostCreateRequest requestDto,
             HttpSession session
     ) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
-        Object response = postService.createPost(projectId, requestDto, loginUserId);
+        PostCreateResponse response = postService.createPost(projectId, requestDto, loginUserId);
 
         return CommonResponse.success("게시글 작성 성공", response);
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -10,7 +10,6 @@ import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 import org.etmetmy.bn_server.domain.post.service.PostService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -27,40 +26,20 @@ public class PostController {
 
     private final PostService postService;
 
-    /**
-     * 게시글 작성 API
-     */
+    // todo: 부모 게시글, 자식 게시글 작성 API
     @PostMapping("/{projectId}/posts")
-    @ActivityLogger(targetType = "Post", action = "CREATE")
-    public CommonResponse<PostCreateResponse> createPost(
-            @PathVariable("projectId") Long projectId,
-            @Valid @RequestBody PostCreateRequest requestDto,
-            HttpSession session) {
-
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-
-        PostCreateResponse response = postService.createPost(projectId, requestDto, loginUserId);
-        return CommonResponse.success("게시글 작성 성공", response);
-    }
-
-    // todo: reply 게시글 작성 API
-    @PostMapping("/{projectId}/posts/{postId}")
-    @ActivityLogger(targetType = "Post", action = "COMMENT_ADD")
-    public CommonResponse<ReplyPostCreateResponse> createReplyPost(
+    public CommonResponse<?> createPost(
             @PathVariable Long projectId,
             @Valid @RequestBody PostCreateRequest requestDto,
-            @PathVariable Long postId,
-            HttpSession session) {
-
+            HttpSession session
+    ) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
+        Object response = postService.createPost(projectId, requestDto, loginUserId);
 
-        ReplyPostCreateResponse response = postService.createReplyPost(projectId, requestDto, postId, loginUserId);
         return CommonResponse.success("게시글 작성 성공", response);
     }
 
-    /**
-     * 게시글 상세 조회
-     */
+    // todo: 게시글 상세 조회 API
     @GetMapping("/{projectId}/posts/{postId}")
     public CommonResponse<PostDetailResponse> getPostDetail(
             @PathVariable Long projectId,
@@ -71,9 +50,7 @@ public class PostController {
 
     }
 
-    /**
-     * 게시글 승인 API
-     */
+    // todo: 게시글 승인 API
     @PatchMapping("/{postId}/approval")
     public ResponseEntity<CommonResponse<Object>> approvePost(
             @PathVariable Long postId,
@@ -84,9 +61,8 @@ public class PostController {
         return ResponseEntity.ok(CommonResponse.success("게시글 승인 완료"));
     }
 
-    /**
-     * 게시글 거절 API
-     */
+
+    // todo: 게시글 거절 API
     @PatchMapping("/{postId}/reject")
     public ResponseEntity<CommonResponse<Object>> rejectPost(
             @PathVariable Long postId,
@@ -97,7 +73,7 @@ public class PostController {
         return ResponseEntity.ok(CommonResponse.success("게시글 거절 완료"));
     }
 
-    // todo : 관리자 및 개발사가 게시글 완료하기 버튼
+    // todo: 관리자 및 개발사가 게시글 완료하기 버튼 API
     @PatchMapping("/{projectId}/posts/{postId}/completion")
     public void completePost(@PathVariable Long projectId,
                              @PathVariable Long postId,

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -113,7 +113,7 @@ public class PostController {
         }
     }
 
-    @PatchMapping("/{projectId}/posts/{postId}")
+    /*@PatchMapping("/{projectId}/posts/{postId}")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     public CommonResponse<PostCreateResponse> updatePost(
             @PathVariable Long projectId,
@@ -126,5 +126,5 @@ public class PostController {
         PostCreateResponse response = postService.updatePost(
                 projectId, postId, requestDto, loginUserId);
         return CommonResponse.success("게시글 수정 성공", response);
-    }
+    }*/
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -33,22 +33,14 @@ public class PostCreateRequest {
     private Long parentId;
 
     // S3에 업로드된 파일 정보 목록 (선택 사항)
-    private List<FileInfo> fileInfos;
+    private List<Long> fileIds;
 
     // 링크 URL 목록 (선택 사항)
     private List<String> linkUrls;
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class FileInfo {
-        private String fileUrl;
-        private Long fileSize;
-    }
-
     public static class Converter {
-        public static Post toEntity(Project project, User user, Stage stage, Long postNumber, Post parent, PostCreateRequest requestDto) {
+        public static Post toEntity(
+                Project project, User user, Stage stage, Long postNumber, Post parent, PostCreateRequest requestDto) {
 
             return Post.builder()
                     .project(project)

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -30,6 +30,8 @@ public class PostCreateRequest {
     @NotNull(message = "단계 ID는 필수입니다.")
     private Long stageId;
 
+    private Long parentId;
+
     // S3에 업로드된 파일 정보 목록 (선택 사항)
     private List<FileInfo> fileInfos;
 
@@ -46,45 +48,18 @@ public class PostCreateRequest {
     }
 
     public static class Converter {
-        public static Post toEntity(
-                Project project,
-                User user,
-                String title,
-                String content,
-                Stage stage,
-                Long postNumber) {
+        public static Post toEntity(Project project, User user, Stage stage, Long postNumber, Post parent, PostCreateRequest requestDto) {
 
             return Post.builder()
                     .project(project)
                     .user(user)
-                    .parentPostId(null) //일반 게시글은 부모 없음
-                    .title(title)
-                    .content(content)
-                    .stage(stage)
-                    .postNumber(postNumber)
-                    .isCompleted(false)
-                    .build();
-        }
-        public static Post toReplyEntity(
-                Project project,
-                User user,
-                Post post,
-                String title,
-                String content,
-                Stage stage,
-                Long postNumber) {
-
-            return Post.builder()
-                    .project(project)
-                    .user(user)
-                    .parentPostId(post.getPostId()) //일반 게시글은 부모 없음
-                    .title(title)
-                    .content(content)
+                    .parentPostId(parent != null ? parent.getPostId() : null)
+                    .title(requestDto.getTitle())
+                    .content(requestDto.getContent())
                     .stage(stage)
                     .postNumber(postNumber)
                     .isCompleted(false)
                     .build();
         }
     }
-
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
@@ -52,7 +52,7 @@ public class PostCreateResponse {
 
 
     public static class Converter {
-        public static PostCreateResponse from(
+        /*public static PostCreateResponse from(
             Post post, List<File> files, List<Link> links
         ) {
             // 파일 목록 변환 (삭제되지 않은 파일만)
@@ -71,6 +71,19 @@ public class PostCreateResponse {
                     .updatedAt(post.getUpdatedAt())
                     .files(fileInfos)
                     .linkUrls(linkUrls)
+                    .build();
+        }*/
+        public static PostCreateResponse from(Post post){
+            return PostCreateResponse.builder()
+                    .postId(post.getPostId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .stageId(post.getStage().getId())
+                    .createdByUserId(post.getUser().getId())
+                    .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .files(FileInfoDTO.Converter.from(post.getFiles()))
+                    .linkUrls(LinkInfoDTO.Converter.toUrlList(post.getLinks()))
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.UploadedFileDto;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.link.dto.LinkInfoDTO;
 import org.etmetmy.bn_server.domain.link.entity.Link;
@@ -23,6 +24,9 @@ public class PostCreateResponse {
 
     @JsonProperty("postId")
     private Long postId;
+
+    @JsonProperty("parentPostId")
+    private Long parentPostId;
 
     @JsonProperty("title")
     private String title;
@@ -45,34 +49,14 @@ public class PostCreateResponse {
     private LocalDateTime updatedAt;
 
     @JsonProperty("files")
-    private List<FileInfoDTO> files;
+    private List<UploadedFileDto> files;
 
     @JsonProperty("linkUrls")
-    private List<String> linkUrls;
+    private List<LinkInfoDTO> linkUrls;
 
 
     public static class Converter {
-        /*public static PostCreateResponse from(
-            Post post, List<File> files, List<Link> links
-        ) {
-            // 파일 목록 변환 (삭제되지 않은 파일만)
-            List<FileInfoDTO> fileInfos = FileInfoDTO.Converter.from(files);
 
-            // 링크 목록 변환 (삭제되지 않은 링크만) - LinkInfoDTO 사용
-            List<String> linkUrls = LinkInfoDTO.Converter.toUrlList(links);
-
-            return PostCreateResponse.builder()
-                    .postId(post.getPostId())
-                    .title(post.getTitle())
-                    .content(post.getContent())
-                    .stageId(post.getStage().getId())
-                    .createdByUserId(post.getUser().getId())
-                    .createdAt(post.getCreatedAt())
-                    .updatedAt(post.getUpdatedAt())
-                    .files(fileInfos)
-                    .linkUrls(linkUrls)
-                    .build();
-        }*/
         public static PostCreateResponse from(Post post){
             return PostCreateResponse.builder()
                     .postId(post.getPostId())
@@ -82,8 +66,8 @@ public class PostCreateResponse {
                     .createdByUserId(post.getUser().getId())
                     .createdAt(post.getCreatedAt())
                     .updatedAt(post.getUpdatedAt())
-                    .files(FileInfoDTO.Converter.from(post.getFiles()))
-                    .linkUrls(LinkInfoDTO.Converter.toUrlList(post.getLinks()))
+                    .files(UploadedFileDto.Converter.from(post))
+                    .linkUrls(LinkInfoDTO.Converter.from(post.getLinks()))
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
 import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.file.dto.response.UploadedFileDto;
 import org.etmetmy.bn_server.domain.file.entity.File;
@@ -49,7 +50,7 @@ public class PostCreateResponse {
     private LocalDateTime updatedAt;
 
     @JsonProperty("files")
-    private List<UploadedFileDto> files;
+    private List<FileInfoDTO> files;
 
     @JsonProperty("linkUrls")
     private List<LinkInfoDTO> linkUrls;
@@ -57,17 +58,18 @@ public class PostCreateResponse {
 
     public static class Converter {
 
-        public static PostCreateResponse from(Post post){
+        public static PostCreateResponse from(Post post, List<FileInfoDTO> files, List<LinkInfoDTO> links) {
             return PostCreateResponse.builder()
                     .postId(post.getPostId())
+                    .parentPostId(post.getParentPostId())
                     .title(post.getTitle())
                     .content(post.getContent())
                     .stageId(post.getStage().getId())
                     .createdByUserId(post.getUser().getId())
                     .createdAt(post.getCreatedAt())
                     .updatedAt(post.getUpdatedAt())
-                    .files(UploadedFileDto.Converter.from(post))
-                    .linkUrls(LinkInfoDTO.Converter.from(post.getLinks()))
+                    .files(files)
+                    .linkUrls(links)
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/ReplyPostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/ReplyPostCreateResponse.java
@@ -53,29 +53,4 @@ public class ReplyPostCreateResponse {
     @JsonProperty("linkUrls")
     private List<String> linkUrls;
 
-
-    public static class Converter {
-        public static ReplyPostCreateResponse from(
-                Post post, Post parentPost, List<File> files, List<Link> links
-        ) {
-            // 파일 목록 변환 (삭제되지 않은 파일만)
-            List<FileInfoDTO> fileInfos = FileInfoDTO.Converter.from(files);
-
-            // 링크 목록 변환 (삭제되지 않은 링크만) - LinkInfoDTO 사용
-            List<String> linkUrls = LinkInfoDTO.Converter.toUrlList(links);
-
-            return ReplyPostCreateResponse.builder()
-                    .postId(post.getPostId())
-                    .parentPostId(parentPost.getPostId())
-                    .title(post.getTitle())
-                    .content(post.getContent())
-                    .stageId(post.getStage().getId())
-                    .createdByUserId(post.getUser().getId())
-                    .createdAt(post.getCreatedAt())
-                    .updatedAt(post.getUpdatedAt())
-                    .files(fileInfos)
-                    .linkUrls(linkUrls)
-                    .build();
-        }
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
@@ -17,18 +17,6 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    // 게시글 조회 (files 포함)
-    @Query("select distinct p from Post p " +
-            "left join fetch p.files " +
-            "where p.postId = :postId")
-    Optional<Post> findByIdWithFiles(@Param("postId") Long postId);
-
-    // 게시글 조회 (links 포함)
-    @Query("select distinct p from Post p " +
-            "left join fetch p.links " +
-            "where p.postId = :postId")
-    Optional<Post> findByIdWithLinks(@Param("postId") Long postId);
-
     // 전체 게시글 조회 (User + Stage 함께 조회)
     @Query("select p from Post p " +
             "join fetch p.user u " +

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
@@ -17,12 +17,6 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-
-    @Query("select p from Post p " +
-            "join fetch p.user u " +
-            "where p.postId = :postId")
-    Optional<Post> findByIdWithDetails(@Param("postId") Long postId);
-
     // 게시글 조회 (files 포함)
     @Query("select distinct p from Post p " +
             "left join fetch p.files " +

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
@@ -23,6 +23,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "where p.postId = :postId")
     Optional<Post> findByIdWithDetails(@Param("postId") Long postId);
 
+    // 게시글 조회 (files 포함)
+    @Query("select distinct p from Post p " +
+            "left join fetch p.files " +
+            "where p.postId = :postId")
+    Optional<Post> findByIdWithFiles(@Param("postId") Long postId);
+
+    // 게시글 조회 (links 포함)
+    @Query("select distinct p from Post p " +
+            "left join fetch p.links " +
+            "where p.postId = :postId")
+    Optional<Post> findByIdWithLinks(@Param("postId") Long postId);
+
     // 전체 게시글 조회 (User + Stage 함께 조회)
     @Query("select p from Post p " +
             "join fetch p.user u " +
@@ -99,5 +111,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "WHERE p.request IS NOT NULL " +
             "ORDER BY p.createdAt DESC")
     List<Post> findAllPostsWithRequest();
-
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -6,16 +6,13 @@ import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 
 import java.util.List;
 
 public interface PostService {
     PostDetailResponse getPostDetail(Long postId);
 
-
     void approvePost(Long postId, Long approvingUserId);
-
 
     void rejectPost(Long postId, Long rejectingUserId, String rejectReason);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -22,7 +22,7 @@ public interface PostService {
 
     List<PostListResponse> getPostListByStage(Long projectId, String stage);
 
-    PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
+    //PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
 
     void completePost(Long projectId, Long postId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -23,8 +23,6 @@ public interface PostService {
 
     PostCreateResponse createPost(Long projectId, @Valid PostCreateRequest requestDto, Long loginUserId);
 
-    ReplyPostCreateResponse createReplyPost(Long projectId, @Valid PostCreateRequest requestDto, Long postId, Long loginUserId);
-
     List<PostListResponse> getPostListByStage(Long projectId, String stage);
 
     PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 
+import org.etmetmy.bn_server.domain.comment.repository.CommentRepository;
 import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
@@ -53,8 +54,6 @@ public class PostServiceImpl implements PostService {
     private final LinkService linkService;
     private final FileService fileService;
 
-    private final FileRepository fileRepository;
-    private final LinkRepository linkRepository;
     private final CommentRepository commentRepository;
 
     // 1. 게시글 상세 조회 (GET)

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -129,7 +129,7 @@ public class PostServiceImpl implements PostService {
         };
     }
 
-    // 게시글 작성
+    // 게시글 작성 (게시글 저장 → 링크 저장 -> 임시 파일 연결 (post_id, isTemp=false))
     @Override
     @Transactional
     public PostCreateResponse createPost(Long projectId, PostCreateRequest requestDto, Long loginUserId) {
@@ -143,26 +143,20 @@ public class PostServiceImpl implements PostService {
 
         Post parent = null;
         if (requestDto.getParentId() != null) {
-            parent = postRepository.findById(requestDto.getParentId())
-                    .orElseThrow(BoardNotFoundException::new);
-        }
+            parent = postRepository.findById(requestDto.getParentId()).orElseThrow(BoardNotFoundException::new);}
+
+        // 1. 게시글 저장: DTO를 엔티티로 변환 후 DB에 저장, ID 발급
         Post savedPost = postRepository.save(
                 PostCreateRequest.Converter.toEntity(project, user, stage, postNumber, parent, requestDto)
         );
 
+        // 2. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 게시글과 연동
         linkService.saveLinks(savedPost, requestDto.getLinkUrls(), loginUserId);
-        fileService.saveFiles(savedPost, requestDto.getFileInfos(), loginUserId);
 
-        // files, links를 각각 fetch (MultipleBagFetchException 방지)
-        // 첫 번째 쿼리: files 초기화
-        postRepository.findByIdWithFiles(savedPost.getPostId())
-                .orElseThrow(BoardNotFoundException::new);
+        // 3. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회
+        fileService.saveFiles(savedPost, requestDto.getFileIds(), loginUserId);
 
-        // 두 번째 쿼리: links 초기화 (같은 영속성 컨텍스트, files와 links 모두 초기화됨)
-        Post postWithFilesAndLinks = postRepository.findByIdWithLinks(savedPost.getPostId())
-                .orElseThrow(BoardNotFoundException::new);
-
-        return PostCreateResponse.Converter.from(postWithFilesAndLinks);
+        return PostCreateResponse.Converter.from(savedPost);
     }
 
     // 게시글 수정

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -1,16 +1,15 @@
 package org.etmetmy.bn_server.domain.post.service;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
 import org.etmetmy.bn_server.domain.file.service.FileService;
-import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
+import org.etmetmy.bn_server.domain.link.dto.LinkInfoDTO;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.link.service.LinkService;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
@@ -30,7 +29,6 @@ import org.etmetmy.bn_server.exception.custom.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -156,10 +154,14 @@ public class PostServiceImpl implements PostService {
         // 3. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회
         fileService.saveFiles(savedPost, requestDto.getFileIds(), loginUserId);
 
-        return PostCreateResponse.Converter.from(savedPost);
+        // 4. 저장된 데이터 재조회
+        List<File> files = fileRepository.findFilesByPostId(savedPost.getPostId());
+        List<Link> links = linkRepository.findLinksByPostId(savedPost.getPostId());
+
+        return PostCreateResponse.Converter.from(savedPost, FileInfoDTO.Converter.from(files), LinkInfoDTO.Converter.from(links));
     }
 
-    // 게시글 수정
+    /*// 게시글 수정
     @Override
     @Transactional
     public PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId) {
@@ -211,8 +213,8 @@ public class PostServiceImpl implements PostService {
         List<File> savedFiles = fileRepository.findByPost(post);
         List<Link> savedLinks = linkRepository.findByPost(post);
        // todo: 수정예정 return PostCreateResponse.Converter.from(post, savedFiles, savedLinks);
-        return PostCreateResponse.Converter.from(post);
-    }
+         return PostCreateResponse.Converter.from(post);
+    }*/
 
     @Override
     @Transactional

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -2,19 +2,18 @@ package org.etmetmy.bn_server.domain.post.service;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
+import org.etmetmy.bn_server.domain.file.service.FileService;
 import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
+import org.etmetmy.bn_server.domain.link.service.LinkService;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.RequestCreateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.ReplyPostCreateResponse;
 import org.etmetmy.bn_server.domain.post.entity.*;
 import org.etmetmy.bn_server.domain.post.repository.PostNumberCounterRepository;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
@@ -46,9 +45,12 @@ public class PostServiceImpl implements PostService {
     private final UserRepository userRepository;
     private final PostNumberCounterRepository postNumberCounterRepository;
     private final ProjectRepository projectRepository;
+    private final LinkRepository linkRepository; //todo: 게시글 수정 브랜치 다시 파서 지울 예정
+    private final FileRepository fileRepository; //todo: 게시글 수정 브랜치 다시 파서 지울 예정
     private final ProjectMemberRepository projectMemberRepository;
-    private final FileRepository fileRepository;
-    private final LinkRepository linkRepository;
+    private final LinkService linkService;
+    private final FileService fileService;
+
 
     // 1. 게시글 상세 조회 (GET)
     public PostDetailResponse getPostDetail(Long postId) {
@@ -137,108 +139,33 @@ public class PostServiceImpl implements PostService {
         Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
         Stage stage = stageRepository.findById(requestDto.getStageId()).orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
 
-        // Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
-        PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
-                .orElseGet(() -> PostNumberCounter.builder()
-                        .projectId(projectId)
-                        .currentNumber(0L)
-                        .build());
-        Long postNumber = counter.getNextNumber();
-        postNumberCounterRepository.save(counter);
+        Long postNumber = generatePostNumber(projectId);
 
-        // Post 엔티티 생성 및 저장
-        Post post = PostCreateRequest.Converter.toEntity(project, user, requestDto.getTitle(), requestDto.getContent(), stage, postNumber);
-        Post savedPost = postRepository.save(post);
-
-        // Request 엔티티 생성 및 저장
-        requestRepository.save(RequestCreateRequest.Converter.toEntity(savedPost, loginUserId));
-
-        // 파일 처리
-        List<File> savedFiles = new ArrayList<>();
-        if (requestDto.getFileInfos() != null && !requestDto.getFileInfos().isEmpty()) {
-            for (PostCreateRequest.FileInfo fileInfo : requestDto.getFileInfos()) {
-                File file = FileCreateRequest.Converter.toEntity(
-                        fileInfo.getFileUrl(),
-                        fileInfo.getFileSize(),
-                        savedPost,
-                        loginUserId
-                );
-                savedFiles.add(file);
-            }
-            fileRepository.saveAll(savedFiles);
+        Post parent = null;
+        if (requestDto.getParentId() != null) {
+            parent = postRepository.findById(requestDto.getParentId())
+                    .orElseThrow(BoardNotFoundException::new);
         }
+        Post savedPost = postRepository.save(
+                PostCreateRequest.Converter.toEntity(project, user, stage, postNumber, parent, requestDto)
+        );
 
-        // 링크 처리
-        List<Link> savedLinks = new ArrayList<>();
-        if (requestDto.getLinkUrls() != null && !requestDto.getLinkUrls().isEmpty()) {
-            for (String linkUrl : requestDto.getLinkUrls()) {
-                Link link = LinkCreateRequest.Converter.toEntity(linkUrl, savedPost, loginUserId);
-                savedLinks.add(link);
-            }
-            linkRepository.saveAll(savedLinks);
-        }
+        linkService.saveLinks(savedPost, requestDto.getLinkUrls(), loginUserId);
+        fileService.saveFiles(savedPost, requestDto.getFileInfos(), loginUserId);
 
-        // 응답 반환
-        return PostCreateResponse.Converter.from(savedPost, savedFiles, savedLinks);
+        // files, links를 각각 fetch (MultipleBagFetchException 방지)
+        // 첫 번째 쿼리: files 초기화
+        postRepository.findByIdWithFiles(savedPost.getPostId())
+                .orElseThrow(BoardNotFoundException::new);
+
+        // 두 번째 쿼리: links 초기화 (같은 영속성 컨텍스트, files와 links 모두 초기화됨)
+        Post postWithFilesAndLinks = postRepository.findByIdWithLinks(savedPost.getPostId())
+                .orElseThrow(BoardNotFoundException::new);
+
+        return PostCreateResponse.Converter.from(postWithFilesAndLinks);
     }
 
-    @Override
-    @Transactional
-    public ReplyPostCreateResponse createReplyPost(Long projectId, PostCreateRequest requestDto, Long postId, Long loginUserId) {
-
-        // 1. 필요한 엔티티 조회
-        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
-        Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
-        Stage stage = stageRepository.findById(requestDto.getStageId()).orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
-        Post post = postRepository.findById(postId).orElseThrow(BoardNotFoundException::new);
-
-        // 2. Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
-        PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
-                .orElseGet(() -> PostNumberCounter.builder()
-                        .projectId(projectId)
-                        .currentNumber(0L)
-                        .build());
-        Long postNumber = counter.getNextNumber();
-        postNumberCounterRepository.save(counter);
-
-        // 3. Post 엔티티 생성 및 저장
-        Post replyPost = PostCreateRequest.Converter.toReplyEntity(project, user,post, requestDto.getTitle(), requestDto.getContent(), stage, postNumber);
-        Post savedPost = postRepository.save(replyPost);
-
-        // Request 엔티티 생성 및 저장
-        requestRepository.save(RequestCreateRequest.Converter.toEntity(savedPost, loginUserId));
-
-        // 4. 파일 처리
-        List<File> savedFiles = new ArrayList<>();
-        if (requestDto.getFileInfos() != null && !requestDto.getFileInfos().isEmpty()) {
-            for (PostCreateRequest.FileInfo fileInfo : requestDto.getFileInfos()) {
-                File file = FileCreateRequest.Converter.toEntity(
-                        fileInfo.getFileUrl(),
-                        fileInfo.getFileSize(),
-                        savedPost,
-                        loginUserId
-                );
-                savedFiles.add(file);
-            }
-            fileRepository.saveAll(savedFiles);
-        }
-
-        // 5. 링크 처리
-
-        List<Link> savedLinks = new ArrayList<>();
-        if (requestDto.getLinkUrls() != null && !requestDto.getLinkUrls().isEmpty()) {
-            for (String linkUrl : requestDto.getLinkUrls()) {
-                Link link = LinkCreateRequest.Converter.toEntity(linkUrl, savedPost, loginUserId);
-                savedLinks.add(link);
-            }
-            linkRepository.saveAll(savedLinks);
-        }
-
-        // 6. 응답 반환
-        return ReplyPostCreateResponse.Converter.from(savedPost, post, savedFiles, savedLinks);
-    }
-
-    // 게시글 업데이트 API
+    // 게시글 수정
     @Override
     @Transactional
     public PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId) {
@@ -275,10 +202,10 @@ public class PostServiceImpl implements PostService {
             // 기존 링크 삭제 (물리적 삭제 - orphanRemoval로 자동 처리됨)
             linkRepository.deleteAll(existingLinks);
 
-            // 새 링크 추가
+
             List<Link> newLinks = new ArrayList<>();
             for (String linkUrl : requestDto.getLinkUrls()) {
-                Link link = LinkCreateRequest.Converter.toEntity(linkUrl, post, loginUserId);
+                Link link = LinkCreateRequest.Converter.toEntity(post, linkUrl, loginUserId);
                 newLinks.add(link);
             }
             linkRepository.saveAll(newLinks);
@@ -289,7 +216,8 @@ public class PostServiceImpl implements PostService {
         // 8. 응답 반환 (파일, 링크 정보 포함)
         List<File> savedFiles = fileRepository.findByPost(post);
         List<Link> savedLinks = linkRepository.findByPost(post);
-        return PostCreateResponse.Converter.from(post, savedFiles, savedLinks);
+       // todo: 수정예정 return PostCreateResponse.Converter.from(post, savedFiles, savedLinks);
+        return PostCreateResponse.Converter.from(post);
     }
 
     @Override
@@ -332,5 +260,26 @@ public class PostServiceImpl implements PostService {
         if (!post.getUser().getId().equals(loginUserId)) {
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
         }
+    }
+
+    // Counter Table로 프로젝트 내 게시글 번호 생성 (낙관적 락 적용)
+    private Long generatePostNumber(Long projectId) {
+        PostNumberCounter counter = postNumberCounterRepository.findByProjectId(projectId)
+                .orElseGet(() -> {
+                    PostNumberCounter newCounter = PostNumberCounter.builder()
+                            .projectId(projectId)
+                            .currentNumber(0L)
+                            .build();
+
+                    // DB에 먼저 저장
+                    return postNumberCounterRepository.save(newCounter);
+                });
+
+        Long postNumber = counter.getNextNumber();
+
+        // version 증가시키려면 save 반드시 필요
+        postNumberCounterRepository.save(counter);
+
+        return postNumber;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/global/aop/ActivityLogAspect.java
+++ b/src/main/java/org/etmetmy/bn_server/global/aop/ActivityLogAspect.java
@@ -163,9 +163,9 @@ public class ActivityLogAspect {
             if (unwrapped instanceof PostCreateResponse postResponse) {
                 return postResponse.getPostId();
             }
-            if (unwrapped instanceof ReplyPostCreateResponse replyResponse) {
+            /*if (unwrapped instanceof ReplyPostCreateResponse replyResponse) {
                 return replyResponse.getPostId();
-            }
+            }*/
         }
 
         // 3. 일반적인 Long 타입 반환 값 처리


### PR DESCRIPTION
## 📄 작업 내용 요약

### 1️⃣ 부모게시글/자식게시글 통합

  - 이전: 부모 게시글과 답글(자식 게시글)을 별도 API로 구현
  - 변경: 단일 API로 통합, parentId 파라미터로 답글 여부 구분
` POST /api/v1/users/projects/{projectId}/posts`

 ```
 // 부모 게시글
  { "title": "...", "content": "...", "parentId": null, ... }

  // 자식 게시글 (답글)
  { "title": "...", "content": "...", "parentId": 16, ... }
```
 #### 응답 구조 개선

  - PostCreateResponse 단일화: ReplyPostCreateResponse 제거
  - parentPostId 추가: 응답에 부모 게시글 ID 포함
  - 파일/링크 정보 포함: 게시글 작성 시 업로드된 파일과 링크 정보를 응답에 포함

  ### 2️⃣ 파일 업로드 전체 실행 흐름

 ```
 1. Controller: PostController.createPost()
     ↓
  2. Service: PostServiceImpl.createPost()
     ├─ User, Project, Stage 조회
     ├─ 게시글 번호 생성 (generatePostNumber)
     ├─ Post 저장
     ├─ LinkService.saveLinks() - 링크 저장
     ├─ FileService.saveFiles() - 파일 저장
     └─ PostRepository.findByIdWithFilesAndLinks() - 파일/링크 포함 조회
     ↓
  3. Response: PostCreateResponse 반환
```

<img width="854" height="515" alt="image" src="https://github.com/user-attachments/assets/e5cdf053-8c66-4aba-bcfb-13947c8ae123" />
<img width="856" height="814" alt="image" src="https://github.com/user-attachments/assets/80b138e1-5036-4a44-87f3-9df306af1508" />

  
  Removed

  - ❌ ReplyPostCreateResponse.java (삭제)
  - ❌ UploadedFileDto.java (삭제)
## 📎 Issue 번호

<!-- closed #번호 -->
