### PR TITLE
Bug/ 게시글 상세 조회 수정 및 생성 시 Request 여부 확인

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.file.entity.File;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,8 +41,7 @@ public class FileInfoDTO {
      * 삭제된 파일은 제외
      */
     public static class Converter {
-        public static List<FileInfoDTO> from(
-                List<org.etmetmy.bn_server.domain.file.entity.File> files) {
+        public static List<FileInfoDTO> from(List<File> files) {
 
             // 1. files가 null 이면 빈 리스트 반환
             if (files == null) {
@@ -57,7 +57,6 @@ public class FileInfoDTO {
                 if (file.getIsDeleted()) {
                     continue;
                 }
-
                 // File 엔티티의 정보를 FileInfo DTO로 변환
                 fileInfos.add(FileInfoDTO.builder()
                         .fileId(file.getFileId())

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
+import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.user.entity.User;
@@ -32,6 +34,10 @@ public class PostCreateRequest {
 
     private Long parentId;
 
+    // 승인요청 여부 (기본값: false)
+    @Builder.Default
+    private Boolean requestApproval = false;
+
     // S3에 업로드된 파일 정보 목록 (선택 사항)
     private List<Long> fileIds;
 
@@ -51,6 +57,24 @@ public class PostCreateRequest {
                     .stage(stage)
                     .postNumber(postNumber)
                     .isCompleted(false)
+                    .build();
+        }
+
+        /**
+         * 승인요청이 있는 경우 Request 엔티티 생성 (초기 상태: PENDING)
+         * @return Request 엔티티 또는 null (승인요청이 없는 경우)
+         */
+        public static Request toRequestEntity(
+                PostCreateRequest requestDto, Post post, Long requestUserId) {
+
+            if (!Boolean.TRUE.equals(requestDto.getRequestApproval())) {
+                return null;
+            }
+
+            return Request.builder()
+                    .post(post)
+                    .requestUserId(requestUserId)
+                    .approveStatus(RequestStatus.STATUS_PENDING)
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostCreateResponse.java
@@ -55,7 +55,6 @@ public class PostCreateResponse {
     @JsonProperty("linkUrls")
     private List<LinkInfoDTO> linkUrls;
 
-
     public static class Converter {
 
         public static PostCreateResponse from(Post post, List<FileInfoDTO> files, List<LinkInfoDTO> links) {

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostDetailResponse.java
@@ -44,14 +44,16 @@ public class PostDetailResponse {
             // 파일 변환 (삭제되지 않은 파일만)
             List<FileInfoDTO> fileInfos = FileInfoDTO.Converter.from(post.getFiles());
 
-            // 링크 변환 (삭제되지 않은 링크만)
+            // 링크 변환
             List<LinkInfoDTO> linkInfos = LinkInfoDTO.Converter.from(post.getLinks());
 
             // 댓글 변환 (계층 구조 포함)
             List<CommentResponse> commentResponses = convertCommentsToHierarchy(comments);
 
             return PostDetailResponse.builder()
+                    .postId(post.getPostId())
                     .parentPostId(post.getParentPostId())
+                    .userId(author.getId())
                     .authorName(author.getName())
                     .title(post.getTitle())
                     .content(post.getContent())
@@ -60,8 +62,10 @@ public class PostDetailResponse {
                     .stageName(post.getStage().getStageName())
                     .files(fileInfos)
                     .links(linkInfos)
-                    .approveStatus(request.getApproveStatus().getDescription())
-                    .rejectionReason(request.getRejectReason())
+                    .approveStatus(request != null && request.getApproveStatus() != null
+                            ? request.getApproveStatus().getDescription()
+                            : null)
+                    .rejectionReason(request != null ? request.getRejectReason() : null)
                     .comments(commentResponses)
                     .build();
         }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -67,7 +67,7 @@ public class PostServiceImpl implements PostService {
         Request request = requestRepository.findByPostId(postId);
 
         // DTO 변환 (파일, 링크, 댓글 포함)
-        return PostDetailResponse.Converter.fromEntity(post, post.getUser(), comments,request);
+        return PostDetailResponse.Converter.fromEntity(post, post.getUser(), comments, request);
     }
 
     // 2. 게시글 승인
@@ -158,13 +158,19 @@ public class PostServiceImpl implements PostService {
                 PostCreateRequest.Converter.toEntity(project, user, stage, postNumber, parent, requestDto)
         );
 
-        // 2. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 게시글과 연동
+        // 2. 승인요청이 있는 경우에만 Request 엔티티 생성 (초기 상태: PENDING)
+        Request request = PostCreateRequest.Converter.toRequestEntity(requestDto, savedPost, loginUserId);
+        if (request != null) {
+            requestRepository.save(request);
+        }
+
+        // 3. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 게시글과 연동
         linkService.saveLinks(savedPost, requestDto.getLinkUrls(), loginUserId);
 
-        // 3. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회
+        // 4. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회
         fileService.saveFiles(savedPost, requestDto.getFileIds(), loginUserId);
 
-        // 4. 저장된 데이터 재조회
+        // 5. 저장된 데이터 재조회
         List<File> files = fileRepository.findFilesByPostId(savedPost.getPostId());
         List<Link> links = linkRepository.findLinksByPostId(savedPost.getPostId());
 


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 상세 조회 및 생성 시 승인 요청(Request) 처리 로직했습니다.


### 1. 게시글 상세 조회 기능 수정

  - PostController.java: 게시글 상세 조회 API 개선
  - PostServiceImpl.java: 상세 조회 로직 수정
  - Request 상태 확인 로직 추가

### 2. 게시글 생성 시 Request 여부 확인 기능 추가

  - 게시글 생성 시 승인 요청 여부 확인 로직 구현
  - Request 엔티티와의 연동 개선
<img width="1892" height="1172" alt="image" src="https://github.com/user-attachments/assets/076b5c01-2550-4f55-9e10-0972049ae9ec" />

## 📎 Issue 179

<!-- closed #179  -->
