### PR TITLE
Fix/ 게시글 수정 API 개선

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -3,8 +3,10 @@ package org.etmetmy.bn_server.domain.post.controller;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.activityLog.aop.ActivityLogger;
 import org.etmetmy.bn_server.domain.post.dto.request.PostApprovalRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
@@ -58,7 +60,6 @@ public class PostController {
         return ResponseEntity.ok(CommonResponse.success("게시글 승인 완료"));
     }
 
-
     // todo: 게시글 거절 API
     @PatchMapping("posts/{postId}/reject")
     public ResponseEntity<CommonResponse<Object>> rejectPost(
@@ -80,15 +81,10 @@ public class PostController {
         postService.completePost(projectId, postId, loginUserId);
     }
 
-    /**
-     * 게시글 조회(필터)
-     * all : 전체
-     * finished: 완료된 게시글
-     * unfinished : 미완료된 게시글
-     */
-    /**
-     * 게시글 목록 조회 (필터)
-     */
+    // todo: 게시글 목록 조회 (필터) API
+    // all : 전체
+    // finished: 완료된 게시글
+    // unfinished : 미완료된 게시글
     @GetMapping("/{projectId}/posts")
     public CommonResponse<List<PostListResponse>> getPostList(
             @PathVariable Long projectId,
@@ -110,7 +106,7 @@ public class PostController {
         }
     }
 
-    /*@PatchMapping("/{projectId}/posts/{postId}")
+    @PatchMapping("/{projectId}/posts/{postId}")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     public CommonResponse<PostCreateResponse> updatePost(
             @PathVariable Long projectId,
@@ -123,5 +119,5 @@ public class PostController {
         PostCreateResponse response = postService.updatePost(
                 projectId, postId, requestDto, loginUserId);
         return CommonResponse.success("게시글 수정 성공", response);
-    }*/
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostUpdateRequest.java
@@ -1,11 +1,15 @@
 package org.etmetmy.bn_server.domain.post.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
+import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 
 import java.util.List;
@@ -16,15 +20,26 @@ import java.util.List;
 @Builder
 public class PostUpdateRequest {
 
+    @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
     private String title;
 
+    @NotBlank(message = "본문은 필수입니다.")
     private String content;
 
+    @NotNull(message = "단계 ID는 필수입니다.")
     private Long stageId;
 
-    // S3에 업로드된 임시 파일 URL 목록 (선택 사항)
-    private List<String> fileUrls;
+    private Long parentId;
+
+    // 승인요청 여부
+    private Boolean requestApproval;
+
+    // 추가할 파일 ID 목록 (임시 파일 ID, 선택 사항)
+    private List<Long> addFileIds;
+
+    // 삭제할 파일 ID 목록 (기존 파일 ID, 선택 사항)
+    private List<Long> removeFileIds;
 
     // 링크 URL 목록 (선택 사항)
     private List<String> linkUrls;
@@ -47,6 +62,20 @@ public class PostUpdateRequest {
                 post.updateStage(stage);
             }
             // 파일과 링크 업데이트는 Service 레이어에서 별도 처리
+        }
+
+        public static Request toRequestEntity(
+                PostUpdateRequest requestDto, Post post, Long requestUserId) {
+
+            if (!Boolean.TRUE.equals(requestDto.getRequestApproval())) {
+                return null;
+            }
+
+            return Request.builder()
+                    .post(post)
+                    .requestUserId(requestUserId)
+                    .approveStatus(RequestStatus.STATUS_PENDING)
+                    .build();
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
@@ -1,16 +1,11 @@
 package org.etmetmy.bn_server.domain.post.repository;
 
-import jakarta.persistence.LockModeType;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -22,7 +22,7 @@ public interface PostService {
 
     List<PostListResponse> getPostListByStage(Long projectId, String stage);
 
-    //PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
+    PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
 
     void completePost(Long projectId, Long postId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.post.service;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.etmetmy.bn_server.domain.comment.repository.CommentRepository;
@@ -14,6 +15,7 @@ import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.link.service.LinkService;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
@@ -34,6 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -177,7 +180,7 @@ public class PostServiceImpl implements PostService {
         return PostCreateResponse.Converter.from(savedPost, FileInfoDTO.Converter.from(files), LinkInfoDTO.Converter.from(links));
     }
 
-    /*// 게시글 수정
+    // 게시글 수정
     @Override
     @Transactional
     public PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId) {
@@ -191,7 +194,7 @@ public class PostServiceImpl implements PostService {
             throw new BusinessException(ErrorCode.POST_PROJECT_MISMATCH);
         }
 
-        // 3. 작성자 권한 검증
+        // 3. 작성자 권한 검증 (작성자만 수정 가능)
         if(!post.getUser().getId().equals(loginUserId)){
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
         }
@@ -206,31 +209,68 @@ public class PostServiceImpl implements PostService {
         // 5. 기본 필드 업데이트 (title, content, stage)
         PostUpdateRequest.Converter.applyTo(requestDto, post, stage);
 
-        // 6. 링크 업데이트 (링크 URL이 제공된 경우)
-        if (requestDto.getLinkUrls() != null) {
-            // 기존 링크 조회
-            List<Link> existingLinks = linkRepository.findByPost(post);
+        // 6. 파일 삭제 처리 (removeFileIds가 제공된 경우)
+        if (requestDto.getRemoveFileIds() != null && !requestDto.getRemoveFileIds().isEmpty()) {
+            List<File> filesToDelete = fileRepository.findAllById(requestDto.getRemoveFileIds());
 
-            // 기존 링크 삭제 (물리적 삭제 - orphanRemoval로 자동 처리됨)
-            linkRepository.deleteAll(existingLinks);
-
-
-            List<Link> newLinks = new ArrayList<>();
-            for (String linkUrl : requestDto.getLinkUrls()) {
-                Link link = LinkCreateRequest.Converter.toEntity(post, linkUrl, loginUserId);
-                newLinks.add(link);
+            // 파일이 해당 게시글에 속하는지 검증
+            for (File file : filesToDelete) {
+                if (file.getPost() == null || !file.getPost().getPostId().equals(postId)) {
+                    throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
+                }
             }
-            linkRepository.saveAll(newLinks);
+
+            // Soft Delete 적용
+            for (File file : filesToDelete) {
+                file.softDelete(loginUserId);
+            }
         }
 
-        // 7. TODO: 파일 업데이트 로직은 별도 API로 구현 필요
+        // 7. 파일 추가 처리 (addFileIds가 제공된 경우)
+        if (requestDto.getAddFileIds() != null && !requestDto.getAddFileIds().isEmpty()) {
+            fileService.saveFiles(post, requestDto.getAddFileIds(), loginUserId);
+        }
 
-        // 8. 응답 반환 (파일, 링크 정보 포함)
-        List<File> savedFiles = fileRepository.findByPost(post);
-        List<Link> savedLinks = linkRepository.findByPost(post);
-       // todo: 수정예정 return PostCreateResponse.Converter.from(post, savedFiles, savedLinks);
-         return PostCreateResponse.Converter.from(post);
-    }*/
+        // 8. 링크 업데이트 (링크 URL이 제공된 경우)
+        if (requestDto.getLinkUrls() != null) {
+            // 기존 링크 조회 및 삭제
+            List<Link> existingLinks = linkRepository.findByPost(post);
+            linkRepository.deleteAll(existingLinks);
+
+            // 새 링크 저장
+            linkService.saveLinks(post, requestDto.getLinkUrls(), loginUserId);
+        }
+
+        // 9. 승인요청 상태 업데이트 (requestApproval 필드가 제공된 경우)
+        if (requestDto.getRequestApproval() != null) {
+            // 기존 PENDING 상태의 Request 조회
+            Request existingRequest = requestRepository.findByPostPostIdAndApproveStatus(
+                    postId, RequestStatus.STATUS_PENDING).orElse(null);
+
+            if (Boolean.TRUE.equals(requestDto.getRequestApproval())) {
+                // 승인요청을 원하는 경우
+                if (existingRequest == null) {
+                    // 기존 승인요청이 없으면 새로 생성
+                    Request newRequest = PostUpdateRequest.Converter.toRequestEntity(requestDto, post, loginUserId);
+                    requestRepository.save(Objects.requireNonNull(newRequest));
+                }
+                // 이미 PENDING 상태의 승인요청이 있으면 그대로 유지
+            } else {
+                // 승인요청을 취소하는 경우
+                if (existingRequest != null) {
+                    // 기존 PENDING 승인요청이 있으면 삭제
+                    requestRepository.delete(existingRequest);
+                }
+            }
+        }
+
+        // 10. 저장된 데이터 재조회
+        List<File> files = fileRepository.findFilesByPostId(post.getPostId());
+        List<Link> links = linkRepository.findLinksByPostId(post.getPostId());
+
+        return PostCreateResponse.Converter.from(
+                post, FileInfoDTO.Converter.from(files), LinkInfoDTO.Converter.from(links));
+    }
 
     @Override
     @Transactional


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 수정 시 파일 및 승인요청 관리 로직의 문제점을 개선하고, 보다 명확하고 안전한 API 구조로 개선했습니다.

----
## 🔧 주요 변경사항

### 1. 파일 관리 방식 개선 

  - 기존: fileIds 필드로 파일 관리 → 기존 파일 삭제 로직 누락, 중복 파일 추가 문제
  - 개선: addFileIds, removeFileIds 필드로 분리
    - addFileIds: 추가할 임시 파일 ID 목록
    - removeFileIds: 삭제할 기존 파일 ID 목록

### 2. 파일 삭제 로직 구현

  - removeFileIds 제공 시 해당 파일들을 Soft Delete 처리
  - 파일이 해당 게시글에 속하는지 검증
  - 기존 file.softDelete() 메서드 활용

### 3. 승인요청(Request) 상태 변경 기능 추가

  - requestApproval 필드로 승인요청 상태 관리
    - true: 승인요청 추가 (PENDING 상태의 Request 생성)
    - false: 승인요청 취소 (PENDING 상태의 Request 삭제)
    - null (필드 미전송): 기존 상태 유지
  - 안전성:
    - PENDING 상태의 요청만 처리 (APPROVED/REJECTED 건드리지 않음)
    - 중복 생성 방지
<img width="1884" height="1640" alt="image" src="https://github.com/user-attachments/assets/c9c384bc-dde8-4490-9493-0359cd1eb481" />
<img width="1896" height="1376" alt="image" src="https://github.com/user-attachments/assets/38482b19-c105-4c04-ad5a-300564a0f74a" />

----
## 📎 Issue 183

<!-- closed #183  -->
