### PR TITLE
bug:개별 프로젝트 체크리스트 추가 오류 수정

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectAddCheckListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/dto/response/ProjectAddCheckListResponse.java
@@ -27,7 +27,7 @@ public class ProjectAddCheckListResponse {
                     .projectId(projectCheckList.getProject().getId())
                     .checklistId(projectCheckList.getCheckListId())
                     .checklistContent(checkList.getContent())
-                    .answererId(projectCheckList.getAnswererId().getId())
+                    .answererId(projectCheckList.getAnswererId() != null ? projectCheckList.getAnswererId().getId() : null)
                     .checked(projectCheckList.getChecked())
                     .build();
         }


### PR DESCRIPTION
## 📄 작업 내용 요약
프로젝트에 처음 추가될 때 아무도 답변하지 않은 상태이기 때문에 answererId가 null인데
코드에서 null 체크없이 .getId()를 호출했기 때문에 에러 발생한걸 수정했습니다.
## 📎 Issue 번호

<!-- closed #번호 -->
