### PR TITLE
Feat/ 댓글 삭제 구현 (soft-delete)

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/controller/CommentController.java
@@ -67,4 +67,16 @@ public class CommentController {
         CommentListResponse response = commentService.getCommentsByPostId(postId);
         return CommonResponse.success("댓글 목록 조회 성공", response);
     }
+
+    //todo: 댓글 삭제 (soft delete)
+    @Operation(summary = "댓글 삭제 (soft delete)", description = "해당 댓글과 함께 파일도 soft delete 합니다.")
+    @DeleteMapping("/comment/{commentId}")
+    public CommonResponse<Void> softDeleteComment(@PathVariable Long commentId, HttpServletRequest servletRequest)
+    {
+        HttpSession session = servletRequest.getSession(false);
+        Long userId = SessionUtil.getLoginUserId(session);
+
+        commentService.softDeleteComment(commentId,userId);
+        return CommonResponse.success("댓글 삭제 성공", null);
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/comment/entity/Comment.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/entity/Comment.java
@@ -54,6 +54,9 @@ public class Comment extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name =  "deleted_by")
+    private Long deletedBy;
+
     //파일 목록
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
     @lombok.Builder.Default
@@ -68,5 +71,12 @@ public class Comment extends BaseEntity {
     // 댓글 업데이트 메서드
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    // 댓글 soft delete
+    public void softDelete(Long deletedBy) {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/repository/CommentRepository.java
@@ -11,24 +11,24 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    // 1. 특정 Post에 대한 최상위 댓글 조회 (parent가 NULL인 댓글)
+    // 1. 특정 Post에 대한 최상위 댓글 조회 (parent가 NULL인 댓글, 삭제되지 않은 댓글만)
     @Query("SELECT c FROM Comment c " +
             "JOIN FETCH c.user u " +
-            "WHERE c.post.postId = :postId AND c.parent IS NULL " +
+            "WHERE c.post.postId = :postId AND c.parent IS NULL AND c.isDeleted = false " +
             "ORDER BY c.createdAt ASC")
     List<Comment> findRootCommentsByPostId(@Param("postId") Long postId);
 
-    // 2. 특정 부모 댓글 ID에 대한 대댓글 조회
+    // 2. 특정 부모 댓글 ID에 대한 대댓글 조회 (삭제되지 않은 댓글만)
     @Query("SELECT c FROM Comment c " +
             "JOIN FETCH c.user u " +
-            "WHERE c.parent = :parentCommentId " +
+            "WHERE c.parent = :parentCommentId AND c.isDeleted = false " +
             "ORDER BY c.createdAt ASC")
     List<Comment> findRepliesByParentId(@Param("parentCommentId") Long parentCommentId);
 
-    // 3. 특정 Post의 모든 댓글 조회 (한 번에)
+    // 3. 특정 Post의 모든 댓글 조회 (한 번에, 삭제되지 않은 댓글만)
     @Query("SELECT c FROM Comment c " +
             "JOIN FETCH c.user u " +
-            "WHERE c.post.postId = :postId " +
+            "WHERE c.post.postId = :postId AND c.isDeleted = false " +
             "ORDER BY c.createdAt ASC")
     List<Comment> findAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/comment/service/CommentService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/service/CommentService.java
@@ -12,4 +12,6 @@ public interface CommentService {
     CommentListResponse getCommentsByPostId(Long postId);
 
     CommentResponse updateComment(Long commentId, @Valid CommentUpdateRequest request, String clientIp, Long userId);
+
+    void softDeleteComment(Long commentId, Long userId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/service/CommentServiceImpl.java
@@ -215,4 +215,31 @@ public class CommentServiceImpl implements CommentService {
         return CommentResponse.Converter.from(
                 comment, FileInfoDTO.Converter.from(files), LinkInfoDTO.Converter.from(links), List.of());
     }
+
+    // 댓글 삭제 (soft delete)
+    public void softDeleteComment(Long commentId, Long userId){
+
+        // 1. 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BOARD_COMMENT_NOT_FOUND));
+
+        // 2. 작성자 권한 검증 (작성자만 삭제 가능)
+        if(!comment.getUser().getId().equals(userId)){
+            throw new BusinessException(ErrorCode.COMMENT_PERMISSION_DENIED);
+        }
+
+        // 3. 이미 삭제된 댓글 확인
+        if (comment.getIsDeleted()) {
+            throw new BusinessException(ErrorCode.COMMENT_ALREADY_DELETED);
+        }
+        // 소프트 삭제
+        comment.softDelete(userId);
+        commentRepository.save(comment);
+
+        // 4. 댓글과 연결된 파일 삭제
+        List<File> file = fileRepository.findFilesByCommentId(comment.getCommentId());
+        for (File fileToDelete : file) {
+            fileToDelete.softDelete(userId);
+        }
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/company/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/company/dto/request/CompanyCreateRequest.java
@@ -15,7 +15,6 @@ public class CompanyCreateRequest {
     private String companyAddress;
     private String companyCeo;
 
-    @NotBlank(message = "회사 전화번호는 필수입니다.")
     private String companyPhone; // 회사 대표 번호
 
     @NotBlank(message = "담당자명은 필수입니다.")

--- a/src/main/java/org/etmetmy/bn_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
 
     //todo: 로그아웃
     @Operation(summary = "로그아웃", description = "현재 세션을 종료하고 로그아웃합니다")
-    @GetMapping("/logout")
+    @PostMapping("/logout")
     public CommonResponse<Object> logout(
             HttpServletRequest request
     ){

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_PARENT_COMMENT(400, "C002", "유효하지 않은 부모 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(404, "C003", "부모 댓글을 찾을 수 없습니다."),
     COMMENT_PERMISSION_DENIED(403,"C004","댓글 수정/삭제 권한이 없습니다."),
+    COMMENT_ALREADY_DELETED(400, "B002_3", "이미 삭제된 댓글입니다."),
 
     //공통 에러
     INVALID_INPUT_VALUE(400, "I001", "잘못된 입력값입니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
댓글 soft delete API를 구현하고, 댓글 삭제 시 연결된 파일도 함께 soft delete 처리하도록 개선했습니다.

## 주요 변경사항

### 1. 댓글 Soft Delete API 구현

  - 기능: 댓글과 연결된 파일을 함께 soft delete 처리
  - 권한: 작성자만 삭제 가능 (권한 검증 포함)
  - 중복 방지: 이미 삭제된 댓글 재삭제 차단

### 2. Comment 엔티티 확장

  - deletedBy 필드 추가 (삭제자 ID 추적)
  - softDelete(Long deletedBy) 메서드 구현

### 3. 삭제 비즈니스 로직

  다음 순서로 처리:
  1. 댓글 존재 여부 확인
  2. 작성자 권한 검증
  3. 중복 삭제 방지 (isDeleted 체크)
  4. 댓글 soft delete
  5. 연결된 모든 파일 soft delete

### 4. 에러 코드 추가

  - COMMENT_ALREADY_DELETED (400, "B002_3"): 중복 삭제 시도 방지


### 5. 댓글 조회 쿼리에 Soft Delete 조건 추가

### 6. 요청사항 해결

- 로그아웃 HTTP 메서드 수정

  - GET /logout → POST /logout
  - RESTful API 관례 준수 (상태 변경 작업은 POST 사용)

- companyPhone 필드의 @NotBlank 제거 

<img width="1828" height="476" alt="image" src="https://github.com/user-attachments/assets/cfa6f8a2-42e0-4678-94ff-f05c5def2ef0" />
<img width="1946" height="698" alt="image" src="https://github.com/user-attachments/assets/1c12daee-1ab7-4e5c-ba6b-28681295d53e" />
<img width="1986" height="772" alt="image" src="https://github.com/user-attachments/assets/b75ef95e-62c6-4ca8-a4e0-f9e7823b68c6" />

## 📎 Issue 227

<!-- closed #227  -->
