### PR TITLE
Fix/ 파일 타이틀 수정 및 파일 projectId 연동

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
@@ -19,9 +20,9 @@ public class FileCreateRequest {
     public static class Converter {
 
         // 임시 파일 엔티티 생성 (MultipartFile 기반)
-        public static File toEntity(Post post, String fileUrl, MultipartFile file, Long uploadedBy) {
+        public static File toEntity(Project project, String fileUrl, MultipartFile file, Long uploadedBy) {
             return File.builder()
-                    .post(post)
+                    .project(project)
                     .fileTitle(extractFileName(fileUrl))
                     .filePath(fileUrl) // S3 저장 경로
                     .fileSize(file.getSize())

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileCreateRequest.java
@@ -4,10 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.file.dto.response.S3UploadResult;
 import org.etmetmy.bn_server.domain.file.entity.File;
-import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.project.entity.Project;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor
@@ -19,39 +18,19 @@ public class FileCreateRequest {
 
     public static class Converter {
 
-        // 임시 파일 엔티티 생성 (MultipartFile 기반)
-        public static File toEntity(Project project, String fileUrl, MultipartFile file, Long uploadedBy) {
+        // 임시 파일 엔티티 생성 (S3UploadResult 기반)
+        public static File toEntity(Project project, S3UploadResult uploadResult, Long uploadedBy) {
             return File.builder()
                     .project(project)
-                    .fileTitle(extractFileName(fileUrl))
-                    .filePath(fileUrl) // S3 저장 경로
-                    .fileSize(file.getSize())
-                    .fileType(extractFileType(fileUrl))
+                    .s3FileTitle(uploadResult.getStoredFileName())       // UUID_원본파일명
+                    .originalFileTitle(uploadResult.getOriginalFileName()) // 원본 파일명
+                    .filePath(uploadResult.getFileUrl())                  // S3 저장 경로
+                    .fileSize(uploadResult.getFileSize())
+                    .fileType(uploadResult.getFileType())
                     .uploadedBy(uploadedBy)
                     .isTemp(true)
                     .isDeleted(false)
                     .build();
-        }
-
-        // URL 에서 파일명 추출
-        public static String extractFileName(String url) {
-            if (url == null || url.isEmpty()) return "unknown";
-
-            // 1. 쿼리 제거
-            String path = url.split("\\?")[0];
-
-            // 2. 마지막 슬래시 이후 추출
-            int lastSlash = path.lastIndexOf('/');
-            return lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
-        }
-
-        // URL 에서 파일 확장자 추출
-        public static String extractFileType(String url) {
-            if (url == null || url.isEmpty()) return "unknown";
-
-            String path = url.split("\\?")[0]; // 쿼리 제거
-            int lastDot = path.lastIndexOf('.');
-            return lastDot >= 0 ? path.substring(lastDot + 1).toLowerCase() : "unknown";
         }
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/ActiveFileListDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/ActiveFileListDTO.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.file.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 public class ActiveFileListDTO {
 
     private Long fileId;
-    private String fileTitle;
+    private String fileOriginalFileName;
     private String filePath;
     private String fileType;
     private Long fileSize;
@@ -38,7 +39,7 @@ public class ActiveFileListDTO {
         public static ActiveFileListDTO from(File file) {
             return ActiveFileListDTO.builder()
                     .fileId(file.getFileId())
-                    .fileTitle(file.getFileTitle())
+                    .fileOriginalFileName(file.getOriginalFileTitle())
                     .filePath(file.getFilePath())
                     .fileType(file.getFileType())
                     .fileSize(file.getFileSize())

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
@@ -23,8 +23,8 @@ public class FileInfoDTO {
     @JsonProperty("fileId")
     private Long fileId;
 
-    @JsonProperty("fileName")
-    private String fileName;
+    @JsonProperty("fileOriginalFileName")
+    private String fileOriginalFileName;
 
     @JsonProperty("fileSize")
     private Long fileSize;
@@ -59,7 +59,7 @@ public class FileInfoDTO {
                 // File 엔티티의 정보를 FileInfo DTO로 변환
                 fileInfos.add(FileInfoDTO.builder()
                         .fileId(file.getFileId())
-                        .fileName(file.getFileTitle())
+                        .fileOriginalFileName(file.getOriginalFileTitle())
                         .fileSize(file.getFileSize())
                         .fileUrl(file.getFilePath())
                         .fileType(file.getFileType())

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
@@ -1,0 +1,14 @@
+package org.etmetmy.bn_server.domain.file.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class S3UploadResult {
+    private String originalFileName;  // 사용자가 업로드한 원본 파일명
+    private String storedFileName;     // S3에 저장된 파일명 (UUID_원본파일명)
+    private String fileUrl;            // S3 파일 URL
+    private Long fileSize;             // 파일 크기
+    private String fileType;           // 파일 타입
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class S3UploadResult {
-    private String originalFileName;  // 사용자가 업로드한 원본 파일명
+    private String originalFileName;   // 사용자가 업로드한 원본 파일명
     private String storedFileName;     // S3에 저장된 파일명 (UUID_원본파일명)
     private String fileUrl;            // S3 파일 URL
     private Long fileSize;             // 파일 크기

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
@@ -21,7 +21,8 @@ import java.util.stream.Collectors;
 public class TempFileListDTO {
 
     private Long fileId;
-    private String fileTitle;
+    private String fileS3Name;
+    private String fileOriginalFileName;
     private String filePath;
     private String fileType;
     private Long fileSize;
@@ -34,7 +35,8 @@ public class TempFileListDTO {
         public static TempFileListDTO from(File file) {
             return TempFileListDTO.builder()
                     .fileId(file.getFileId())
-                    .fileTitle(file.getFileTitle())
+                    .fileS3Name(file.getS3FileTitle())
+                    .fileOriginalFileName(file.getOriginalFileTitle())
                     .filePath(file.getFilePath())
                     .fileType(file.getFileType())
                     .fileSize(file.getFileSize())

--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.etmetmy.bn_server.domain.checkList.entity.CheckList;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.project.entity.Project;
@@ -43,8 +42,11 @@ public class File extends BaseEntity {
     @JoinColumn(name = "project_check_list_id")
     private ProjectCheckList projectCheckList;
 
-    @Column(name = "file_title", nullable = false, length = 255)
-    private String fileTitle;
+    @Column(name = "s3_file_title", nullable = false, length = 255)
+    private String s3FileTitle; // UUID_파일명
+
+    @Column(name = "original_file_title", nullable = false, length = 255)
+    private String originalFileTitle; // 사용자가 업로드한 이름
 
     @Column(name = "file_path", nullable = false, length = 500)
     private String filePath;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -28,6 +28,10 @@ public class File extends BaseEntity {
     private Long fileId;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
@@ -67,10 +71,6 @@ public class File extends BaseEntity {
 
     @Column(name = "deleted_by")
     private Long deletedBy;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
-    private Project project;
 
 
     public void softDelete(Long deletedBy) {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -3,6 +3,7 @@ package org.etmetmy.bn_server.domain.file.service;
 import jakarta.servlet.http.HttpSession;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.S3UploadResult;
 import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
@@ -28,7 +29,7 @@ public interface FileService {
     void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
 
     // S3 업로드 메서드
-    public String uploadToS3(MultipartFile file);
+    public S3UploadResult uploadToS3(MultipartFile file);
 
     // 삭제에 필요한 key 반환
     public String getKeyFromFileUrls(String fileUrl);

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -81,6 +81,8 @@ public class FileServiceImpl implements FileService {
     @Transactional
     public List<TempFileListDTO> postFiles(Long projectId, List<MultipartFile> files,Long uploadedBy) {
 
+        Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
+
         List<File> savedFiles = new ArrayList<>();
 
         for (MultipartFile file : files) {
@@ -89,7 +91,7 @@ public class FileServiceImpl implements FileService {
             String fileUrl = uploadToS3(file);
 
             // 2. 임시 파일 엔티티 생성 (post = null, isTemp = true)
-            File fileEntity = FileCreateRequest.Converter.toEntity(null, fileUrl, file, uploadedBy);
+            File fileEntity = FileCreateRequest.Converter.toEntity(project, fileUrl, file, uploadedBy);
 
             // 3. DB에 저장
             File saved = fileRepository.save(fileEntity);

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.ActiveFileListDTO;
+import org.etmetmy.bn_server.domain.file.dto.response.S3UploadResult;
 import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
@@ -88,10 +89,10 @@ public class FileServiceImpl implements FileService {
         for (MultipartFile file : files) {
 
             // 1. S3 업로드
-            String fileUrl = uploadToS3(file);
+            S3UploadResult uploadResult = uploadToS3(file);
 
             // 2. 임시 파일 엔티티 생성 (post = null, isTemp = true)
-            File fileEntity = FileCreateRequest.Converter.toEntity(project, fileUrl, file, uploadedBy);
+            File fileEntity = FileCreateRequest.Converter.toEntity(project, uploadResult, uploadedBy);
 
             // 3. DB에 저장
             File saved = fileRepository.save(fileEntity);
@@ -176,27 +177,41 @@ public class FileServiceImpl implements FileService {
 
     // 6. S3 업로드 메서드
     @Override
-    public String uploadToS3(MultipartFile file) {
+    public S3UploadResult uploadToS3(MultipartFile file) {
 
         String originalFilename = file.getOriginalFilename();
-        String s3FileName = UUID.randomUUID() + "_" + originalFilename;
+        String storedFileName = UUID.randomUUID() + "_" + originalFilename;
 
         try (InputStream is = file.getInputStream()) {
 
             PutObjectRequest req = PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(s3FileName)
+                    .key(storedFileName)
                     .acl(ObjectCannedACL.PUBLIC_READ)
                     .contentType(file.getContentType())
                     .contentLength(file.getSize())
                     .build();
 
             s3Client.putObject(req, RequestBody.fromInputStream(is, file.getSize()));
+
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
         }
-        return s3Client.utilities().getUrl(url -> url.bucket(bucketName).key(s3FileName))
+
+        String fileUrl = s3Client.utilities()
+                .getUrl(url -> url.bucket(bucketName).key(storedFileName))
                 .toString();
+
+        String fileType = extractFileType(originalFilename);
+
+        return new S3UploadResult(originalFilename, storedFileName, fileUrl, file.getSize(), fileType);
+    }
+
+    // 파일 확장자 추출 헬퍼 메서드
+    private String extractFileType(String filename) {
+        if (filename == null || filename.isEmpty()) return "unknown";
+        int lastDot = filename.lastIndexOf('.');
+        return lastDot >= 0 ? filename.substring(lastDot + 1).toLowerCase() : "unknown";
     }
 
     // 7. 삭제에 필요한 key 반환

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -118,18 +118,16 @@ public class PostController {
 
     // todo: 게시글 수정 API
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다")
-    @PatchMapping("/{projectId}/posts/{postId}")
+    @PatchMapping("/posts/{postId}")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     public CommonResponse<PostCreateResponse> updatePost(
-            @PathVariable Long projectId,
             @PathVariable Long postId,
             @Valid @RequestBody PostUpdateRequest requestDto,
             HttpSession session) {
 
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
-        PostCreateResponse response = postService.updatePost(
-                projectId, postId, requestDto, loginUserId);
+        PostCreateResponse response = postService.updatePost(postId, requestDto, loginUserId);
         return CommonResponse.success("게시글 수정 성공", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -22,7 +22,7 @@ public interface PostService {
 
     List<PostListResponse> getPostListByStage(Long projectId, String stage);
 
-    PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
+    PostCreateResponse updatePost(Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId);
 
     void completePost(Long projectId, Long postId, Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -182,33 +182,28 @@ public class PostServiceImpl implements PostService {
     // 게시글 수정
     @Override
     @Transactional
-    public PostCreateResponse updatePost(Long projectId, Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId) {
+    public PostCreateResponse updatePost(Long postId, @Valid PostUpdateRequest requestDto, Long loginUserId) {
 
         // 1. 게시글 조회
         Post post = postRepository.findById(postId)
                 .orElseThrow(BoardNotFoundException::new);
 
-        // 2. 게시글이 해당 프로젝트에 속하는지 검증
-        if (!post.getProject().getId().equals(projectId)) {
-            throw new BusinessException(ErrorCode.POST_PROJECT_MISMATCH);
-        }
-
-        // 3. 작성자 권한 검증 (작성자만 수정 가능)
+        // 2. 작성자 권한 검증 (작성자만 수정 가능)
         if(!post.getUser().getId().equals(loginUserId)){
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
         }
 
-        // 4. Stage 조회
+        // 3. Stage 조회
         Stage stage = null;
         if (requestDto.getStageId() != null) {
             stage = stageRepository.findById(requestDto.getStageId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.STAGE_NOT_FOUND));
         }
 
-        // 5. 기본 필드 업데이트 (title, content, stage)
+        // 4. 기본 필드 업데이트 (title, content, stage)
         PostUpdateRequest.Converter.applyTo(requestDto, post, stage);
 
-        // 6. 파일 삭제 처리 (removeFileIds가 제공된 경우)
+        // 5. 파일 삭제 처리 (removeFileIds가 제공된 경우)
         if (requestDto.getRemoveFileIds() != null && !requestDto.getRemoveFileIds().isEmpty()) {
             List<File> filesToDelete = fileRepository.findAllById(requestDto.getRemoveFileIds());
 
@@ -225,12 +220,12 @@ public class PostServiceImpl implements PostService {
             }
         }
 
-        // 7. 파일 추가 처리 (addFileIds가 제공된 경우)
+        // 6. 파일 추가 처리 (addFileIds가 제공된 경우)
         if (requestDto.getAddFileIds() != null && !requestDto.getAddFileIds().isEmpty()) {
             fileService.saveFiles(post, requestDto.getAddFileIds(), loginUserId);
         }
 
-        // 8. 링크 업데이트 (링크 URL이 제공된 경우)
+        // 7. 링크 업데이트 (링크 URL이 제공된 경우)
         if (requestDto.getLinkUrls() != null) {
             // 기존 링크 조회 및 삭제
             List<Link> existingLinks = linkRepository.findByPost(post);
@@ -240,7 +235,7 @@ public class PostServiceImpl implements PostService {
             linkService.saveLinks(post, requestDto.getLinkUrls(), loginUserId);
         }
 
-        // 9. 승인요청 상태 업데이트 (requestApproval 필드가 제공된 경우)
+        // 8. 승인요청 상태 업데이트 (requestApproval 필드가 제공된 경우)
         if (requestDto.getRequestApproval() != null) {
             // 기존 PENDING 상태의 Request 조회
             Request existingRequest = requestRepository.findByPostPostIdAndApproveStatus(
@@ -263,7 +258,7 @@ public class PostServiceImpl implements PostService {
             }
         }
 
-        // 10. 저장된 데이터 재조회
+        // 9. 저장된 데이터 재조회
         List<File> files = fileRepository.findFilesByPostId(post.getPostId());
         List<Link> links = linkRepository.findLinksByPostId(post.getPostId());
 

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -83,7 +83,7 @@ public class ProjectServiceImpl implements ProjectService {
         // 3. 이미지가 있을 경우 S3에 업로드하고 URL 받기
         if (image != null && !image.isEmpty()) {
             // S3 업로드
-            String imageUrl = fileService.uploadToS3(image);
+            String imageUrl = fileService.uploadToS3(image).getFileUrl();
             // 프로젝트에 이미지 주소 저장
             project.setProjectImageUrl(imageUrl);
         }
@@ -607,7 +607,7 @@ public class ProjectServiceImpl implements ProjectService {
         // 이미지가 있을 경우 S3에 업로드하고 URL 받기
         if (image != null && !image.isEmpty()) {
             // S3 업로드
-            String imageUrl = fileService.uploadToS3(image);
+            String imageUrl = fileService.uploadToS3(image).getFileUrl();
             // 프로젝트에 이미지 주소 저장
             project.setProjectImageUrl(imageUrl);
             projectRepository.save(project);


### PR DESCRIPTION
## 📄 작업 내용 요약

### 1. 임시 파일 업로드 시 프로젝트 연결 

  - 문제: 임시 파일 업로드 시 프로젝트 정보가 연결되지 않음
  - 해결: FileCreateRequest.Converter.toEntity()에서 project 파라미터 추가
  - 영향: 임시 파일도 어떤 프로젝트에 속하는지 추적 가능

### 2. 파일명 필드 구조 개선 

####  2-1. File 엔티티 필드명 변경

```
  // Before
  private String fileTitle;  // 불명확한 필드명

  // After
  private String s3FileTitle;        // S3 저장 파일명 (UUID_원본파일명)
  private String originalFileTitle;  // 사용자 업로드 원본 파일명
```

####  2-2. S3UploadResult DTO 추가

####  2-3. FileService 개선

  - uploadToS3() 반환 타입: String → S3UploadResult
  - 파일 업로드 결과를 구조화하여 반환
  - 파일 확장자 추출 헬퍼 메서드 추가

####  2-4. 관련 DTO 업데이트

  - TempFileListDTO: fileS3Name, fileOriginalFileName 필드 추가
  - ActiveFileListDTO: fileS3Name, fileOriginalFileName 필드 추가
  - FileInfoDTO: fileS3Name, fileOriginalFileName 필드 추가

####  2-5. ProjectServiceImpl 수정

  - 프로젝트 이미지 업로드: uploadToS3().getFileUrl() 호출

<img width="1816" height="1332" alt="image" src="https://github.com/user-attachments/assets/084d1774-0ac3-42ba-91d0-f196747b20c2" />

## 📎 Issue 229

<!-- closed #229 -->
