### PR TITLE
Feat/ 삭제된 게시글 복원

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -81,6 +81,11 @@ public class File extends BaseEntity {
         this.deletedBy = deletedBy;
     }
 
+    public void restore() {
+        isDeleted = false;
+        deletedAt = null;
+    }
+
     // 공통 내부 처리
     private void attach(Post post, Comment comment, Long uploadedBy) {
         this.post = post;

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -2,18 +2,21 @@ package org.etmetmy.bn_server.domain.post.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.activityLog.aop.ActivityLogger;
 import org.etmetmy.bn_server.domain.post.dto.request.PostApprovalRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
 import org.etmetmy.bn_server.domain.post.service.PostService;
+import org.etmetmy.bn_server.domain.project.dto.request.ProjectRestoreRequest;
+import org.etmetmy.bn_server.domain.project.dto.response.ProjectRestoreResponse;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -141,5 +144,17 @@ public class PostController {
 
         postService.softDeletePost(postId,userId);
         return CommonResponse.success("게시글 삭제 성공", null);
+    }
+
+    //todo: 삭제된 게시글 복원
+    @Operation(summary = "게시글 복원", description = "휴지통에 있는 게시글을 복원합니다")
+    @PatchMapping("/posts/restore")
+    public CommonResponse<PostRestoreResponse> restoreDeletedPost(
+            HttpSession session, @Valid @RequestBody PostRestoreRequest request)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        PostRestoreResponse response = postService.restoreDeletedPost(loginUserId, request);
+
+        return CommonResponse.success("삭제된 게시글 복원 성공", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -15,8 +15,6 @@ import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
 import org.etmetmy.bn_server.domain.post.service.PostService;
-import org.etmetmy.bn_server.domain.project.dto.request.ProjectRestoreRequest;
-import org.etmetmy.bn_server.domain.project.dto.response.ProjectRestoreResponse;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostRestoreRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostRestoreRequest.java
@@ -1,0 +1,18 @@
+package org.etmetmy.bn_server.domain.post.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostRestoreRequest {
+
+    @JsonProperty("post_ids")
+    private List<Long> postIds;
+
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostRestoreResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostRestoreResponse.java
@@ -1,0 +1,33 @@
+package org.etmetmy.bn_server.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostRestoreResponse {
+
+    @JsonProperty("restored_count")
+    private Long restoredCount;
+
+    @JsonProperty("restored_ids")
+    private List<Long> restoredIds;
+
+    public static class Converter {
+        public static PostRestoreResponse from(List<Post> posts) {
+
+            return PostRestoreResponse.builder()
+                    .restoredCount((long)posts.size())
+                    .restoredIds(posts.stream().map(Post::getPostId).toList())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostRestoreResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostRestoreResponse.java
@@ -21,12 +21,16 @@ public class PostRestoreResponse {
     @JsonProperty("restored_ids")
     private List<Long> restoredIds;
 
+    @JsonProperty("user_id")
+    private Long userId;
+
     public static class Converter {
-        public static PostRestoreResponse from(List<Post> posts) {
+        public static PostRestoreResponse from(List<Post> posts, Long userId) {
 
             return PostRestoreResponse.builder()
                     .restoredCount((long)posts.size())
                     .restoredIds(posts.stream().map(Post::getPostId).toList())
+                    .userId(userId)
                     .build();
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/entity/Post.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/entity/Post.java
@@ -109,4 +109,10 @@ public class Post extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = deletedBy;
     }
+
+    // 게시글 restore
+    public void restore() {
+        isDeleted = false;
+        deletedAt = null;
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -2,10 +2,13 @@ package org.etmetmy.bn_server.domain.post.service;
 
 import jakarta.validation.Valid;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
+import org.etmetmy.bn_server.domain.project.dto.response.ProjectRestoreResponse;
 
 import java.util.List;
 
@@ -27,6 +30,8 @@ public interface PostService {
     void completePost(Long projectId, Long postId, Long loginUserId);
 
     void softDeletePost(Long postId, Long userId);
+
+    PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request);
 }
 
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.comment.repository.CommentRepository;
 import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
-import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
 import org.etmetmy.bn_server.domain.file.service.FileService;
@@ -15,10 +14,12 @@ import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.link.service.LinkService;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
 import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
 import org.etmetmy.bn_server.domain.post.entity.*;
 import org.etmetmy.bn_server.domain.post.repository.PostNumberCounterRepository;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
@@ -324,6 +325,44 @@ public class PostServiceImpl implements PostService {
         for (File fileToDelete : postFiles) {
             fileToDelete.softDelete(userId);
         }
+    }
+
+    // 게시글 복원
+    @Override
+    @Transactional
+    public PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request){
+
+        // 1. 권한 검증
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        if (user.getRole() != Role.ADMIN) {
+            throw new BusinessException(ErrorCode.DELETED_PROJECT_ACCESS_DENIED);
+        }
+
+        // 2. 요청한 프로젝트 ID 조회
+        List<Long> postIds = request.getPostIds();
+        List<Post> posts = postRepository.findAllById(postIds);
+
+        // 3. 존재 개수 비교
+        if (posts.size() != postIds.size()) {
+            throw new ProjectNotFoundException("존재하지 않는 게시글이 포함되어 있습니다.");
+        }
+
+        // 4. 삭제 여부 체크 후 restore
+        posts.forEach(post -> {
+            if (!post.getIsDeleted()) {
+                throw new BusinessException(ErrorCode.BOARD_NOT_DELETED);
+            }
+            post.restore();
+
+            // 게시글 내 파일도 restore
+            List<File> postFiles = fileRepository.findFilesByPostId(post.getPostId());
+            for (File fileToDelete : postFiles) {
+                fileToDelete.restore();
+            }
+        });
+
+        postRepository.saveAll(posts);
+        return PostRestoreResponse.Converter.from(posts);
     }
 
     // 프로젝트–게시글 소속 검증

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -332,10 +332,10 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request){
 
-        // 1. 권한 검증
+        // 1. 권한 검증 (관리자만)
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
         if (user.getRole() != Role.ADMIN) {
-            throw new BusinessException(ErrorCode.DELETED_PROJECT_ACCESS_DENIED);
+            throw new BusinessException(ErrorCode.DELETED_BOARD_ACCESS_DENIED);
         }
 
         // 2. 요청한 프로젝트 ID 조회
@@ -344,7 +344,7 @@ public class PostServiceImpl implements PostService {
 
         // 3. 존재 개수 비교
         if (posts.size() != postIds.size()) {
-            throw new ProjectNotFoundException("존재하지 않는 게시글이 포함되어 있습니다.");
+            throw new BoardNotFoundException("존재하지 않는 게시글이 포함되어 있습니다.");
         }
 
         // 4. 삭제 여부 체크 후 restore
@@ -362,7 +362,7 @@ public class PostServiceImpl implements PostService {
         });
 
         postRepository.saveAll(posts);
-        return PostRestoreResponse.Converter.from(posts);
+        return PostRestoreResponse.Converter.from(posts, user.getId());
     }
 
     // 프로젝트–게시글 소속 검증

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -17,10 +17,11 @@ public enum ErrorCode {
     // 게시글 관련 에러
     BOARD_POST_NOT_FOUND(404, "B001", "게시글을 찾을 수 없습니다."),
     BOARD_PERMISSION_DENIED(403, "B003", "게시글 수정/삭제 권한이 없습니다."),
-    BOARD_ALREADY_DELETED(400, "B004", "이미 삭제된 게시글입니다."),
-    BOARD_NOT_DELETED(400, "B004", "이미 삭제된 게시글입니다."),
+    BOARD_ALREADY_DELETED(400, "B006", "이미 삭제된 게시글입니다."),
+    BOARD_NOT_DELETED(400, "B005", "삭제되지 않은 게시글은 복구할 수 없습니다."),
     BOARD_INVALID_FILTER(400,"B005", "유효하지 않은 게시글 필터입니다."),
     POST_PROJECT_MISMATCH(400, "P014", "게시글이 해당 프로젝트에 속하지 않습니다."),
+    DELETED_BOARD_ACCESS_DENIED(403,"D006","삭제된 게시글에 접근 권한이 없습니다."),
 
     // 댓글 관련 에러
     BOARD_COMMENT_NOT_FOUND(404, "C001", "댓글을 찾을 수 없습니다."),

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     BOARD_POST_NOT_FOUND(404, "B001", "게시글을 찾을 수 없습니다."),
     BOARD_PERMISSION_DENIED(403, "B003", "게시글 수정/삭제 권한이 없습니다."),
     BOARD_ALREADY_DELETED(400, "B004", "이미 삭제된 게시글입니다."),
+    BOARD_NOT_DELETED(400, "B004", "이미 삭제된 게시글입니다."),
     BOARD_INVALID_FILTER(400,"B005", "유효하지 않은 게시글 필터입니다."),
     POST_PROJECT_MISMATCH(400, "P014", "게시글이 해당 프로젝트에 속하지 않습니다."),
 


### PR DESCRIPTION
## 📄 작업 내용 요약
### 1. Controller
  - 게시글 복원 엔드포인트 추가
  - 세션에서 사용자 ID 추출 및 서비스 호출

### 2. Service 
  - 권한 검증: ADMIN만 복원 가능
  - 존재성 검증: 요청한 모든 게시글 ID가 DB에 존재하는지 확인
  - 삭제 상태 검증: isDeleted = true인 게시글만 복원 가능
  - 연관 파일 복원: 게시글 복원 시 첨부 파일도 자동 복원

### 3. Entity 변경
  - Post.java: restore() 메서드 추가
  public void restore() {
      isDeleted = false;
      deletedAt = null;
  }
  - File.java: restore() 메서드 추가 (동일 로직)

### 4. DTO 추가
  - PostRestoreRequest.java: 복원할 게시글 ID 리스트
  - PostRestoreResponse.java: 복원된 게시글 정보 응답
<img width="1836" height="778" alt="image" src="https://github.com/user-attachments/assets/a19604d6-b2cb-49c1-9cf9-86bf766344ed" />

## 📎 Issue 240

<!-- closed #240  -->
