### PR TITLE
Feature/ 삭제된 게시글 영구삭제 (Hard Delete)

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/dto/request/CommentUpdateRequest.java
@@ -19,8 +19,6 @@ public class CommentUpdateRequest {
     @NotBlank(message = "댓글 내용은 필수입니다.")
     private String content;
 
-    private Long parentId;
-
     // 추가할 파일 ID 목록 (임시 파일 ID, 선택 사항)
     private List<Long> addFileIds;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/comment/dto/response/CommentResponse.java
@@ -33,7 +33,7 @@ public class CommentResponse {
 
             return CommentResponse.builder()
                 .commentId(comment.getCommentId())
-                .parentId( comment.getParent() != null ? comment.getParent().getCommentId() : null )
+                .parentId(comment.getParent() != null ? comment.getParent().getCommentId() : null )
                 .userId(comment.getUser().getId())
                 .userName(comment.getUser().getName())
                 .content(comment.getContent())

--- a/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
@@ -28,8 +28,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
             "AND f.isDeleted = false")
     List<File> findAllByProjectId(@Param("projectId") Long projectId);
 
-    List<File> findByPost(Post post);
-
     @Query("SELECT f FROM File f " +
             "WHERE f.projectCheckList.projectCheckListId = :projectCheckListId " +
             "AND f.isDeleted = false")
@@ -45,4 +43,7 @@ public interface FileRepository extends JpaRepository<File, Long> {
 
     @Query("select f from File f where f.comment.post.postId = :postId")
     List<File> findByPostId(@Param("postId") Long postId);
+
+    @Query("select f from File f where f.post.postId in :postIds")
+    List<File> findByPostIds(List<Long> postIds);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -6,15 +6,8 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.activityLog.aop.ActivityLogger;
-import org.etmetmy.bn_server.domain.post.dto.request.PostApprovalRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
-import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListByStageResponse;
+import org.etmetmy.bn_server.domain.post.dto.request.*;
+import org.etmetmy.bn_server.domain.post.dto.response.*;
 import org.etmetmy.bn_server.domain.post.service.PostService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -167,5 +160,17 @@ public class PostController {
         PostRestoreResponse response = postService.restoreDeletedPost(loginUserId, request);
 
         return CommonResponse.success("삭제된 게시글 복원 성공", response);
+    }
+
+    // Todo: 삭제된 게시글 영구삭제 (hard delete)
+    @DeleteMapping("/posts/trash")
+    public CommonResponse<PostPermanentDeleteResponse> deleteDeletedPost(
+            HttpSession session,
+            @Valid @RequestBody PostPermanentDeleteRequest request)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        PostPermanentDeleteResponse response = postService.deleteDeletedPost(loginUserId, request);
+
+        return CommonResponse.success("삭제된 게시글 영구삭제 성공", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -163,6 +163,7 @@ public class PostController {
     }
 
     // Todo: 삭제된 게시글 영구삭제 (hard delete)
+    @Operation(summary = "삭제된 게시글 영구삭제", description = "휴지통에 있는 게시글을 DB와 S3에서 완전히 삭제합니다")
     @DeleteMapping("/posts/trash")
     public CommonResponse<PostPermanentDeleteResponse> deleteDeletedPost(
             HttpSession session,

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostPermanentDeleteRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostPermanentDeleteRequest.java
@@ -1,0 +1,18 @@
+package org.etmetmy.bn_server.domain.post.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPermanentDeleteRequest {
+
+    @JsonProperty("post_ids")
+    private List<Long> postIds;
+
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostPermanentDeleteResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/response/PostPermanentDeleteResponse.java
@@ -1,0 +1,34 @@
+package org.etmetmy.bn_server.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPermanentDeleteResponse {
+
+    @JsonProperty("deleted_count")
+    private Long deletedCount;
+
+    @JsonProperty("deleted_ids")
+    private List<Long> deletedIds;
+
+
+    public static class Converter {
+        public static PostPermanentDeleteResponse from(List<Post> posts) {
+
+            return PostPermanentDeleteResponse.builder()
+                    .deletedCount((long)posts.size())
+                    .deletedIds(posts.stream().map(Post::getPostId).toList())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -2,13 +2,10 @@ package org.etmetmy.bn_server.domain.post.service;
 
 import jakarta.validation.Valid;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostPermanentDeleteRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
-import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListByStageResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.*;
 import org.etmetmy.bn_server.domain.project.dto.response.ProjectRestoreResponse;
 
 import java.util.List;
@@ -33,6 +30,8 @@ public interface PostService {
     void softDeletePost(Long postId, Long userId);
 
     PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request);
+
+    PostPermanentDeleteResponse deleteDeletedPost(Long loginUserId, @Valid PostPermanentDeleteRequest request);
 }
 
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -344,8 +344,8 @@ public class PostServiceImpl implements PostService {
 
             // 게시글 내 파일도 restore
             List<File> postFiles = fileRepository.findFilesByPostId(post.getPostId());
-            for (File fileToDelete : postFiles) {
-                fileToDelete.restore();
+            for (File fileToRestore : postFiles) {
+                fileToRestore.restore();
             }
         });
 
@@ -368,8 +368,8 @@ public class PostServiceImpl implements PostService {
         }
 
         // 3. 삭제 여부 체크
-        posts.forEach(project -> {
-            if (!project.getIsDeleted()) {
+        posts.forEach(post -> {
+            if (!post.getIsDeleted()) {
                 throw new BusinessException(ErrorCode.BOARD_NOT_DELETED);}
         });
 
@@ -377,7 +377,7 @@ public class PostServiceImpl implements PostService {
         List<File> files = fileRepository.findByPostIds(postIds);
         fileService.deleteFilesFromS3(files);
 
-        // 5. 프로젝트 삭제 (Cascade로 연관 엔티티도 삭제)
+        // 5. 게시글 삭제 (Cascade로 연관 엔티티도 삭제)
         postRepository.deleteAll(posts);
 
         return PostPermanentDeleteResponse.Converter.from(posts);

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -15,13 +15,10 @@ import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.link.service.LinkService;
 import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.PostPermanentDeleteRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
 import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
-import org.etmetmy.bn_server.domain.post.dto.response.PostCreateResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostDetailResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListByStageResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.dto.response.PostRestoreResponse;
+import org.etmetmy.bn_server.domain.post.dto.response.*;
 import org.etmetmy.bn_server.domain.post.entity.*;
 import org.etmetmy.bn_server.domain.post.repository.PostNumberCounterRepository;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
@@ -354,6 +351,36 @@ public class PostServiceImpl implements PostService {
 
         postRepository.saveAll(posts);
         return PostRestoreResponse.Converter.from(posts, user.getId());
+    }
+
+    // 게시글 영구삭제 (hard delete)
+    @Override
+    @Transactional
+    public PostPermanentDeleteResponse deleteDeletedPost(Long loginUserId, @Valid PostPermanentDeleteRequest request){
+
+        // 1. 삭제 요청한 게시글 ID 목록 조회
+        List<Long> postIds = request.getPostIds();
+        List<Post> posts = postRepository.findAllById(postIds);
+
+        // 2. 존재 개수 비교
+        if (posts.size() != postIds.size()) {
+            throw new BoardNotFoundException("존재하지 않는 게시글이 포함되어 있습니다.");
+        }
+
+        // 3. 삭제 여부 체크
+        posts.forEach(project -> {
+            if (!project.getIsDeleted()) {
+                throw new BusinessException(ErrorCode.BOARD_NOT_DELETED);}
+        });
+
+        // 4. S3 파일 삭제
+        List<File> files = fileRepository.findByPostIds(postIds);
+        fileService.deleteFilesFromS3(files);
+
+        // 5. 프로젝트 삭제 (Cascade로 연관 엔티티도 삭제)
+        postRepository.deleteAll(posts);
+
+        return PostPermanentDeleteResponse.Converter.from(posts);
     }
 
     // 프로젝트–게시글 소속 검증

--- a/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/repository/ProjectRepository.java
@@ -99,5 +99,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findActiveProjectsByProjectIds(@Param("projectIds") List<Long> projectIds);
 
     Page<Project> findByProjectNameContainingIgnoreCaseAndIsDeleted(String searchKeyword, Boolean isDeleted, Pageable pageable);
+
     Page<Project> findByIsDeleted(Boolean isDeleted, Pageable pageable);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
+
 aws:
   s3:
     access-key: ${AWS_ACCESS_KEY}
@@ -54,10 +55,6 @@ server:
   servlet:
     session:
       tracking-modes: cookie
-  tomcat:
-    max-swallow-size: -1
-    max-http-form-post-size: -1
-  max-http-request-header-size: 16384
 
 springdoc:
   api-docs:
@@ -71,7 +68,5 @@ logging:
     root: INFO
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
-    org.etmetmy.bn_server.global.aop.ActivityLogAspect: DEBUG
-    org.etmetmy.bn_server.domain.activityLog: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,8 +25,8 @@ spring:
       file-size-threshold: 0B # 파일을 디스크에 저장하지 않고 메모리에 저장하는 최소 크기 (default: 0B)
       max-file-size: 100MB # 한개 파일의 최대 사이즈 (default: 1MB)
       max-request-size: 100MB # 한개 요청의 최대 사이즈 (default: 10MB)
-
-  #매일 설정
+      
+ #매일 설정
   mail:
     host: ${MAIL_HOST:smtp.gmail.com}
     port: ${MAIL_PORT:587}


### PR DESCRIPTION
## 📄 작업 내용 요약
Soft delete된 게시글들을 DB에서 완전히 삭제했습니다.
- 복수 게시글 일괄 삭제 지원 (postIds 리스트)
    - S3 파일도 함께 삭제
    - Cascade로 연관 엔티티(댓글, 파일, 링크) 자동 삭제

### 1. 삭제된 게시글 영구삭제 API
  - 엔드포인트: DELETE /api/v1/users/projects/posts/trash
  - 목적: Soft delete된 게시글을 DB와 S3에서 완전히 삭제
  - Request: PostPermanentDeleteRequest
```
  {
    "post_ids": [1, 2, 3]
  }
```
  - Response: PostPermanentDeleteResponse
```
  {
    "deleted_count": 3,
    "deleted_ids": [1, 2, 3]
  }
```

###  2. 댓글 수정 시 parentId 처리 로직 개선
  - parentId 검증 로직 수정

##  테스트 완료

  - Cascade 설정으로 댓글, 파일, 링크 자동 삭제
 
<img width="1828" height="694" alt="image" src="https://github.com/user-attachments/assets/ba6693d2-00fd-4e43-92ac-7f3d69591d68" />

## 📎 Issue 246

<!-- closed #246  -->
