### PR TITLE
Fix/ fileSize 포맷팅 구현

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/ActiveFileListDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/ActiveFileListDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.etmetmy.bn_server.domain.file.entity.File;
 
 import java.time.LocalDateTime;
@@ -25,7 +26,7 @@ public class ActiveFileListDTO {
     private String fileOriginalFileName;
     private String filePath;
     private String fileType;
-    private Long fileSize;
+    private String fileSize;
 
     private String postTitle;
     private Long postId;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileInfoDTO.java
@@ -27,7 +27,7 @@ public class FileInfoDTO {
     private String fileOriginalFileName;
 
     @JsonProperty("fileSize")
-    private Long fileSize;
+    private String fileSize;
 
     @JsonProperty("fileUrl")
     private String fileUrl;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
@@ -16,7 +16,7 @@ import org.etmetmy.bn_server.domain.post.entity.Post;
 public class FileListResponse {
     private Long fileId;
     private String fileTitle;
-    private Long fileSize;
+    private String fileSize;
     private String filePath;
 
     public static FileListResponse from(File file) {

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/S3UploadResult.java
@@ -9,6 +9,6 @@ public class S3UploadResult {
     private String originalFileName;   // 사용자가 업로드한 원본 파일명
     private String storedFileName;     // S3에 저장된 파일명 (UUID_원본파일명)
     private String fileUrl;            // S3 파일 URL
-    private Long fileSize;             // 파일 크기
+    private String fileSize;             // 파일 크기
     private String fileType;           // 파일 타입
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/TempFileListDTO.java
@@ -25,7 +25,7 @@ public class TempFileListDTO {
     private String fileOriginalFileName;
     private String filePath;
     private String fileType;
-    private Long fileSize;
+    private String fileSize;
 
     private Long uploadUserId;
     private LocalDateTime uploadedAt;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -52,7 +52,7 @@ public class File extends BaseEntity {
     private String filePath;
 
     @Column(name = "file_size", nullable = false)
-    private Long fileSize;
+    private String fileSize;
 
     @Column(name = "file_type", nullable = false, length = 100)
     private String fileType;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -208,8 +208,9 @@ public class FileServiceImpl implements FileService {
                 .toString();
 
         String fileType = extractFileType(originalFilename);
+        String fileSize = formatSize(file.getSize());
 
-        return new S3UploadResult(originalFilename, storedFileName, fileUrl, file.getSize(), fileType);
+        return new S3UploadResult(originalFilename, storedFileName, fileUrl, fileSize, fileType);
     }
 
     // 파일 확장자 추출 헬퍼 메서드
@@ -217,6 +218,12 @@ public class FileServiceImpl implements FileService {
         if (filename == null || filename.isEmpty()) return "unknown";
         int lastDot = filename.lastIndexOf('.');
         return lastDot >= 0 ? filename.substring(lastDot + 1).toLowerCase() : "unknown";
+    }
+
+    // 파일 사이즈를 포맷팅하는 헬퍼 메서드
+    private String formatSize(long bytes) {
+        double mb = bytes / (1024.0 * 1024.0);
+        return String.format("%.1fMB", mb);
     }
 
     // 7. 삭제에 필요한 key 반환
@@ -267,7 +274,6 @@ public class FileServiceImpl implements FileService {
         for (File file : files) {
             try {
                 String fileUrl = file.getFilePath();
-                Long fileId = file.getFileId();
 
                 // S3 key 추출
                 String key = getKeyFromFileUrls(fileUrl);


### PR DESCRIPTION
## 📄 작업 내용 요약

  ### File 엔티티 필드 타입 수정

  #### 1. `fileSize` 필드 타입 변경
  - **File.java:58**
    - 변경 전: `private Long fileSize;`
    - 변경 후: `private String fileSize;`

  #### 2. `formatSize()` 메서드 구현
  -   파일 메타데이터를 사용자 친화적인 형식으로 DB에 저장
  - `fileSize`: Long → String (예: `1572864` → `"1.5MB"`)

  ### 영향 범위

  - File 엔티티
  - FileServiceImpl (S3 업로드 로직)
  - 관련 DTO String 타입으로 수정 

  ### 저장 흐름

  MultipartFile (bytes)
    → uploadToS3()
    → formatSize(bytes) → "1.5MB"
    → S3UploadResult(fileSize: "1.5MB", fileType: "jpg")
    → File 엔티티 생성
    → DB 저장 

<img width="913" height="456" alt="image" src="https://github.com/user-attachments/assets/b9715c93-8720-4201-b29a-dafa65b0e86c" />

## 📎 Issue 259

<!-- closed #259 -->
