### PR TITLE
[Bug] 요청사항 - 프로젝트 게시글 목록 조회 시 발생하는 NullPointerException 버그 수정

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
@@ -8,6 +8,8 @@ import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 
+import java.time.LocalDateTime;
+
 // todo: project 상세 조회 시 필요한 파일 목록
 @Getter
 @Builder
@@ -19,12 +21,17 @@ public class FileListResponse {
     private String fileSize;
     private String filePath;
 
+    private String uploadUserName;
+    private LocalDateTime uploadedAt;
+
     public static FileListResponse from(File file) {
         return FileListResponse.builder()
                 .fileId(file.getFileId())
                 .fileTitle(file.getOriginalFileTitle())
                 .fileSize(file.getFileSize())
                 .filePath(file.getFilePath())
+                .uploadUserName(file.getPost().getUser().getName())
+                .uploadedAt(file.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FileListResponse.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.file.entity.File;
-import org.etmetmy.bn_server.domain.post.dto.response.PostListResponse;
-import org.etmetmy.bn_server.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
 
@@ -25,12 +23,23 @@ public class FileListResponse {
     private LocalDateTime uploadedAt;
 
     public static FileListResponse from(File file) {
+        // 업로드한 사용자 이름 결정 (Post -> Comment -> ProjectCheckList 순서로 확인)
+        String uploadUserName = null;
+
+        if (file.getPost() != null && file.getPost().getUser() != null) {
+            uploadUserName = file.getPost().getUser().getName();
+        } else if (file.getComment() != null && file.getComment().getUser() != null) {
+            uploadUserName = file.getComment().getUser().getName();
+        } else if (file.getProjectCheckList() != null && file.getProjectCheckList().getAnswererId() != null) {
+            uploadUserName = file.getProjectCheckList().getAnswererId().getName();
+        }
+
         return FileListResponse.builder()
                 .fileId(file.getFileId())
                 .fileTitle(file.getOriginalFileTitle())
                 .fileSize(file.getFileSize())
                 .filePath(file.getFilePath())
-                .uploadUserName(file.getPost().getUser().getName())
+                .uploadUserName(uploadUserName)
                 .uploadedAt(file.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
@@ -21,11 +21,18 @@ public interface FileRepository extends JpaRepository<File, Long> {
             "AND f.isDeleted = false")
     List<File> findByProjectId(@Param("projectId") Long projectId);
 
-    // project_id로 직접 조회 (네이티브 쿼리 사용)
-    @Query("SELECT f " +
+    // project_id로 업로드된 파일 조회 (isTemp=false는 post/comment/checkList 중 하나에 연결됨을 보장)
+    @Query("SELECT DISTINCT f " +
             "FROM File f " +
+            "LEFT JOIN FETCH f.post p " +
+            "LEFT JOIN FETCH p.user " +
+            "LEFT JOIN FETCH f.comment c " +
+            "LEFT JOIN FETCH c.user " +
+            "LEFT JOIN FETCH f.projectCheckList pcl " +
+            "LEFT JOIN FETCH pcl.answererId " +
             "WHERE f.project.id = :projectId " +
-            "AND f.isDeleted = false")
+            "AND f.isDeleted = false " +
+            "AND f.isTemp = false")
     List<File> findAllByProjectId(@Param("projectId") Long projectId);
 
     @Query("SELECT f FROM File f " +

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -63,7 +63,7 @@ public class PostController {
 
     // todo: 게시글 거절 API
     @Operation(summary = "게시글 거절", description = "게시글을 거절합니다 (사유 포함)")
-    @PatchMapping("posts/{postId}/reject")
+    @PatchMapping("/posts/{postId}/reject")
     public ResponseEntity<CommonResponse<Object>> rejectPost(
             @PathVariable Long postId,
             @RequestBody @Valid PostApprovalRequest request

--- a/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectAdminController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/controller/ProjectAdminController.java
@@ -157,7 +157,7 @@ public class ProjectAdminController {
         return CommonResponse.success("프로젝트 날짜 수정 성공", response);
     }
 
-    // todo: 개별 프로젝트 soft 삭제 (휴지으로 이동)
+    // todo: 개별 프로젝트 soft 삭제 (휴지통으로 이동)
     @Operation(summary = "프로젝트 삭제", description = "프로젝트를 휴지통으로 이동합니다 (soft delete)")
     @DeleteMapping("/{projectId}")
     @ActivityLogger(action = "DELETE", targetType = "Project")

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -618,7 +618,7 @@ public class ProjectServiceImpl implements ProjectService {
     public void checklistDeleted(Long projectId, Long checkListId) {
         // 프로젝트 체크리스트 존재 확인
         ProjectCheckList projectCheckList = projectChecklistRepository.findByProject_IdAndCheckListId(projectId, checkListId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECTCHECKLIST_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_CHECKLIST_NOT_FOUND));
 
         // 파일 존재 확인
         List<File> files = fileRepository.findByProjectCheckListId(projectCheckList.getProjectCheckListId());


### PR DESCRIPTION
## 📄 작업 내용 요약

### 이슈

  - #256
  - #261 
     
      - 게시글 목록 조회 API에서 500 에러 발생
      - 에러 메시지: Cannot invoke "org.etmetmy.bn_server.domain.post.entity.Post.getUser()" because the return value of 
  "org.etmetmy.bn_server.domain.file.entity.File.getPost()" is null

 
### 문제 확인

  File 엔티티는 Post, Comment, ProjectCheckList 중 하나에만 연결되지만, FileListResponse에서 무조건 file.getPost().getUser().getName()을 호출하여 NPE 발생

  ```
발생 시나리오:
  - Comment에 연결된 파일: file.getPost() → null → NPE
  - ProjectCheckList에 연결된 파일: file.getPost() → null → NPE
  - 임시 파일(아직 연결 안됨): file.getPost() → null → NPE
```

### 수정 사항
  - isTemp = false 조건 추가로 임시파일 제외
  - LEFT JOIN FETCH로 연관 엔티티 한 번에 조회 (N+1 방지)
  - 삭제된 게시글/댓글의 파일은 file.isDeleted = false로 자동 필터링
  
<img width="1413" height="590" alt="image" src="https://github.com/user-attachments/assets/a662dde0-ff4e-416b-80d3-ab9a0c8673b8" />

## 📎 Issue 번호

<!-- closed #번호 -->
