### PR TITLE
Feat/ 삭제된 파일 영구삭제 기능 구현

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -6,10 +6,14 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.file.dto.request.FileDeleteRequest;
+import org.etmetmy.bn_server.domain.file.dto.request.FilePermanentDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.request.FileRestoreRequest;
+import org.etmetmy.bn_server.domain.file.dto.response.FilePermanentDeleteResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.FileRestoreResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.service.FileService;
+import org.etmetmy.bn_server.domain.post.dto.request.PostPermanentDeleteRequest;
+import org.etmetmy.bn_server.domain.post.dto.response.PostPermanentDeleteResponse;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.springframework.http.HttpStatus;
@@ -76,5 +80,19 @@ public class FileController {
         FileRestoreResponse response = fileService.restoreDeletedFiles(loginUserId, request);
 
         return CommonResponse.success("삭제된 파일 복원 성공", response);
+    }
+
+    //todo: 5. 삭제된 파일 영구삭제 API
+    @Operation(summary = "삭제된 파일 영구삭제", description = "휴지통에 있는 파일을 DB와 S3에서 완전히 삭제합니다")
+    @DeleteMapping("/files/trash")
+    public CommonResponse<FilePermanentDeleteResponse> deleteDeletedFiles(
+            @PathVariable Long projectId,
+            HttpSession session,
+            @Valid @RequestBody FilePermanentDeleteRequest request)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        FilePermanentDeleteResponse response = fileService.hardDeleteFiles(loginUserId, request);
+
+        return CommonResponse.success("삭제된 파일 영구삭제 성공", response);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FilePermanentDeleteRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FilePermanentDeleteRequest.java
@@ -1,0 +1,17 @@
+package org.etmetmy.bn_server.domain.file.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilePermanentDeleteRequest {
+
+    @JsonProperty("file_ids")
+    private List<Long> fileIds;
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileRestoreRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/request/FileRestoreRequest.java
@@ -1,6 +1,8 @@
 package org.etmetmy.bn_server.domain.file.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +14,8 @@ import java.util.List;
 @NoArgsConstructor
 public class FileRestoreRequest {
 
+    @NotNull(message = "파일 ID 목록은 필수입니다")
+    @NotEmpty(message = "최소 1개 이상의 파일 ID가 필요합니다")
     @JsonProperty("file_ids")
     private List<Long> fileIds;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FilePermanentDeleteResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/dto/response/FilePermanentDeleteResponse.java
@@ -1,0 +1,34 @@
+package org.etmetmy.bn_server.domain.file.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.etmetmy.bn_server.domain.file.entity.File;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FilePermanentDeleteResponse {
+
+    @JsonProperty("deleted_count")
+    private Long deletedCount;
+
+    @JsonProperty("deleted_ids")
+    private List<Long> deletedIds;
+
+
+    public static class Converter {
+        public static FilePermanentDeleteResponse from(List<File> files) {
+
+            return FilePermanentDeleteResponse.builder()
+                    .deletedCount((long)files.size())
+                    .deletedIds(files.stream().map(File::getFileId).toList())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -2,7 +2,9 @@ package org.etmetmy.bn_server.domain.file.service;
 
 import jakarta.validation.Valid;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
+import org.etmetmy.bn_server.domain.file.dto.request.FilePermanentDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.request.FileRestoreRequest;
+import org.etmetmy.bn_server.domain.file.dto.response.FilePermanentDeleteResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.FileRestoreResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.S3UploadResult;
 import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
@@ -20,9 +22,6 @@ public interface FileService {
 
     // 임시 파일 삭제 (hard delete)
     void deleteTempFile(Long projectId, List<Long> fileIds);
-
-    // 삭제된 파일 영구삭제
-    void deleteHardFile(Long projectId, List<Long> fileIds);
 
     // 업로드 된 파일 삭제 (soft delete)
     void deletePostFiles(Long projectId, Long postId, Long fileId, Long loginUserId);
@@ -50,5 +49,8 @@ public interface FileService {
 
     // 삭제된 파일 복원
     public FileRestoreResponse restoreDeletedFiles(Long loginUserId, @Valid FileRestoreRequest request);
+
+    // 삭제된 파일 영구 삭제
+    FilePermanentDeleteResponse hardDeleteFiles(Long loginUserId, @Valid FilePermanentDeleteRequest request);
 }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -139,6 +139,9 @@ public class FileServiceImpl implements FileService {
 
         // 2. 요청한 파일 ID 조회
         List<Long> fileIds = request.getFileIds();
+        if (fileIds == null || fileIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
         List<File> files = fileRepository.findAllById(fileIds);
 
         // 3. 존재 개수 비교
@@ -158,7 +161,7 @@ public class FileServiceImpl implements FileService {
         return FileRestoreResponse.Converter.from(files, loginUserId);
     }
 
-    // 5. 삭제된 파일 영구 삭제 (hard delete)
+    // 6. 삭제된 파일 영구 삭제 (hard delete)
     @Override
     @Transactional
     public FilePermanentDeleteResponse hardDeleteFiles(Long loginUserId, @Valid FilePermanentDeleteRequest request) {
@@ -171,6 +174,9 @@ public class FileServiceImpl implements FileService {
 
         // 2. 요청한 파일 ID 조회
         List<Long> fileIds = request.getFileIds();
+        if (fileIds == null || fileIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
         List<File> files = fileRepository.findAllById(fileIds);
 
         // 3. 존재 개수 비교
@@ -188,7 +194,7 @@ public class FileServiceImpl implements FileService {
         return FilePermanentDeleteResponse.Converter.from(files);
     }
 
-    // 6. S3 업로드 메서드
+    // 7. S3 업로드 메서드
     @Override
     public S3UploadResult uploadToS3(MultipartFile file) {
 
@@ -234,7 +240,7 @@ public class FileServiceImpl implements FileService {
         return String.format("%.1fMB", mb);
     }
 
-    // 7. 삭제에 필요한 key 반환
+    // 8. 삭제에 필요한 key 반환
     @Override
     public String getKeyFromFileUrls(String fileUrl) {
         try {
@@ -248,7 +254,7 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // 8. S3에서 파일 삭제 후 DB 레코드도 삭제
+    // 9. S3에서 파일 삭제 후 DB 레코드도 삭제
     @Override
     public void deleteFilesFromS3AndDb(List<File> files) {
         for (File file : files) {
@@ -276,7 +282,7 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // 9. S3에서 파일 삭제
+    // 10. S3에서 파일 삭제
     @Override
     public void deleteFilesFromS3(List<File> files) {
         for (File file : files) {
@@ -300,28 +306,28 @@ public class FileServiceImpl implements FileService {
         }
     }
 
-    // 10. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    // 11. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
     @Override
     @Transactional
     public void saveFiles(Post post, List<Long> fileIds, Long loginUserId) {
         saveFilesInternal(post, null, null, fileIds, loginUserId);
     }
 
-    // 11. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    // 12. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
     @Override
     @Transactional
     public void saveFiles(Comment comment, List<Long> fileIds, Long loginUserId) {
         saveFilesInternal(null, comment, null, fileIds, loginUserId);
     }
 
-    // 12. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    // 13. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
     @Override
     @Transactional
     public void saveFiles(ProjectCheckList projectCheckList, List<Long> fileIds, Long loginUserId) {
         saveFilesInternal(null, null, projectCheckList, fileIds, loginUserId);
     }
 
-    // 13. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post/Comment에 저장
+    // 14. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post/Comment에 저장
     private void saveFilesInternal(Post post, Comment comment, ProjectCheckList projectCheckList, List<Long> fileIds, Long loginUserId) {
         if (fileIds == null || fileIds.isEmpty()) {
             return;

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -4,12 +4,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.file.dto.request.FileCreateRequest;
+import org.etmetmy.bn_server.domain.file.dto.request.FilePermanentDeleteRequest;
 import org.etmetmy.bn_server.domain.file.dto.request.FileRestoreRequest;
+import org.etmetmy.bn_server.domain.file.dto.response.FilePermanentDeleteResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.FileRestoreResponse;
 import org.etmetmy.bn_server.domain.file.dto.response.S3UploadResult;
 import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
+import org.etmetmy.bn_server.domain.post.dto.response.PostPermanentDeleteResponse;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
 import org.etmetmy.bn_server.domain.post.service.PostServiceImpl;
@@ -48,7 +51,6 @@ public class FileServiceImpl implements FileService {
     private final UserRepository userRepository;
     private final FileRepository fileRepository;
     private final ProjectRepository projectRepository;
-    private final ProjectMemberRepository projectMemberRepository;
     private final PostRepository postRepository;
     private final S3Client s3Client;
 
@@ -159,30 +161,31 @@ public class FileServiceImpl implements FileService {
     // 5. 삭제된 파일 영구 삭제 (hard delete)
     @Override
     @Transactional
-    public void deleteHardFile(Long projectId, List<Long> fileIds) {
+    public FilePermanentDeleteResponse hardDeleteFiles(Long loginUserId, @Valid FilePermanentDeleteRequest request) {
 
+        // 1. 권한 검증 (관리자만)
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        if (user.getRole() != Role.ADMIN) {
+            throw new BusinessException(ErrorCode.DELETED_FILE_ACCESS_DENIED);
+        }
+
+        // 2. 요청한 파일 ID 조회
+        List<Long> fileIds = request.getFileIds();
         List<File> files = fileRepository.findAllById(fileIds);
 
-        // 파일 개수 검증
+        // 3. 존재 개수 비교
         if (files.size() != fileIds.size()) {
-            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+            throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
         }
 
         for (File file : files) {
-
-            // 프로젝트 소속 검증 (악의적 요청 가정)
-            if (file.getPost() == null ||
-                    file.getPost().getProject() == null ||
-                    !file.getPost().getProject().getId().equals(projectId)) {
-                throw new BusinessException(ErrorCode.FILE_NOT_IN_POST);
-            }
-
-            // 2. 삭제된 파일인지 검증 (영구 삭제는 isDeleted == true인 파일만 허용)
+            // 삭제된 파일인지 검증 (영구 삭제는 isDeleted == true인 파일만 허용)
             if (!file.getIsDeleted()) {
                 throw new BusinessException(ErrorCode.FILE_NOT_DELETED);
             }
         }
         deleteFilesFromS3AndDb(files);
+        return FilePermanentDeleteResponse.Converter.from(files);
     }
 
     // 6. S3 업로드 메서드


### PR DESCRIPTION
## 📄 작업 내용 요약
휴지통에 있는 삭제된 파일을 DB와 S3에서 완전히 제거하는 영구삭제(Hard Delete) API를 구현했습니다.

## 주요 변경사항

### 1. 앤드포인트 추가
  - DELETE /api/v1/users/projects/{projectId}/files/trash
  - 관리자 권한이 있는 사용자만 삭제된 파일을 영구 삭제할 수 있습니다

###  2. 신규 DTO 생성
  - FilePermanentDeleteRequest: 영구 삭제할 파일 ID 목록을 받는 요청 DTO
  - FilePermanentDeleteResponse: 삭제된 파일 개수와 ID 목록을 반환하는 응답 DTO

###  3. Service Layer 구현
  - FileService 인터페이스에 hardDeleteFiles 메서드 추가
  - FileServiceImpl에서 영구 삭제 로직 구현
    - ADMIN 권한 검증
    - 파일 존재 여부 확인
    - soft delete 상태 검증 (isDeleted == true)
    - S3 및 DB에서 완전 삭제

###  4. 코드 개선
  - 미사용 의존성 제거 (ProjectMemberRepository)

 ### 🔒 검증 로직

 - 권한 검증: ADMIN 역할을 가진 사용자만 접근 가능
 - 파일 존재 검증: 요청한 파일 ID가 모두 존재하는지 확인
 - 삭제 상태 검증: soft delete 된 파일(isDeleted = true)만 영구 삭제 허용

### Request/Response 예시

  ```
Request
  {
    "file_ids": [1, 2, 3]
  }

  Response
  {
    "deleted_count": 3,
    "deleted_ids": [1, 2, 3]
  }
```
<img width="1832" height="832" alt="image" src="https://github.com/user-attachments/assets/f867626a-3a2b-4da0-85ca-e99ee98299a0" />

## 📎 Issue 269

<!-- closed #269   -->
