### PR TITLE
[요구사항] Refactor/ 회원정보 수정 - 이미지 업로드

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/repository/FileRepository.java
@@ -61,4 +61,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
 
     @Query("select f from File f where f.post.postId in :postIds")
     List<File> findByPostIds(List<Long> postIds);
+
+    void deleteFileByFilePath(String filePath);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -11,6 +11,7 @@ import org.etmetmy.bn_server.domain.file.dto.response.TempFileListDTO;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
+import org.etmetmy.bn_server.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -52,5 +53,12 @@ public interface FileService {
 
     // 삭제된 파일 영구 삭제
     FilePermanentDeleteResponse hardDeleteFiles(Long loginUserId, @Valid FilePermanentDeleteRequest request);
+
+    // 프로필 이미지 수정 - 기존 이미지 S3에서 삭제
+    void removeOldProfileImage(String oldImageUrl);
+
+    // 프로필 이미지 수정 - 새 이미지 업로드 후 S3 이미지 URL 저장
+    String uploadProfileImage(MultipartFile image, Long userId);
+
 }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -354,4 +354,28 @@ public class FileServiceImpl implements FileService {
 
         fileRepository.saveAll(tempFiles);
     }
+
+    // 15. 프로필 이미지 수정 - 기존 이미지 삭제 (S3 + DB)
+    @Override
+    @Transactional
+    public void removeOldProfileImage(String oldImageUrl){
+
+        // S3 key 추출
+        String key = getKeyFromFileUrls(oldImageUrl);
+
+        // S3 삭제 요청
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+        s3Client.deleteObject(deleteRequest);
+    }
+
+
+    //16. 프로필 이미지 수정 - 새 이미지 업로드 후 S3 이미지 URL 저장
+    public String uploadProfileImage(MultipartFile image, Long userId){
+        S3UploadResult uploadResult = uploadToS3(image);
+
+        return uploadResult.getFileUrl();
+    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/entity/Project.java
@@ -80,7 +80,7 @@ public class Project extends BaseEntity {
         deletedAt = null;
     }
 
-    public void setProjectImageUrl(String imageUrl) {
+    public void updateProjectImage(String imageUrl) {
         projectImageUrl = imageUrl;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -28,7 +28,6 @@ import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.domain.project.repository.ProjectCheckListRepository;
 import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
-import org.etmetmy.bn_server.domain.user.entity.Role;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.domain.user.repository.UserRepository;
 import org.etmetmy.bn_server.exception.custom.InvalidInputException;
@@ -634,7 +633,7 @@ public class ProjectServiceImpl implements ProjectService {
             // S3 업로드
             String imageUrl = fileService.uploadToS3(image).getFileUrl();
             // 프로젝트에 이미지 주소 저장
-            project.setProjectImageUrl(imageUrl);
+            project.updateProjectImage(imageUrl);
             projectRepository.save(project);
         }
         return ProjectUpdateResponse.Converter.from(project);

--- a/src/main/java/org/etmetmy/bn_server/domain/user/controller/UserController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/controller/UserController.java
@@ -21,7 +21,9 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User", description = "사용자 인증 및 관리 API")
 @RequestMapping("/api/v1")
@@ -150,14 +152,27 @@ public class UserController {
         return CommonResponse.success("비밀번호가 성공적으로 변경되었습니다.", response);
     }
 
+    // todo: 회원정보 수정
     @Operation(summary = "본인 정보 수정", description = "로그인한 사용자가 자신의 정보를 수정합니다")
-    @PutMapping("/users/{userId}")
+    @PutMapping("/users")
     public CommonResponse<UserSelfUpdateResponse> updateMyInfo(@RequestBody UserSelfUpdateRequest request, HttpSession session) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
         UserSelfUpdateResponse response = userService.updateMyInfo(loginUserId, request);
 
         return CommonResponse.success("사용자 정보 수정 완료", response);
+    }
+
+    // todo: 회원정보 수정 - 이미지 업로드
+    @Operation(summary = "본인 이미지 수정", description = "로그인한 사용자가 자신의 프로필이미지를 수정합니다")
+    @PutMapping("/users/profile-image")
+    public CommonResponse<UserSelfUpdateResponse> uploadProfileImage(
+            @RequestPart MultipartFile image,
+            HttpSession session
+    ) {
+        Long userId = SessionUtil.getLoginUserId(session);
+        UserSelfUpdateResponse response = userService.updateProfileImage(userId, image);
+        return CommonResponse.success("프로필 이미지 변경 완료", response);
     }
 
     /**

--- a/src/main/java/org/etmetmy/bn_server/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/dto/request/UserUpdateRequest.java
@@ -15,6 +15,9 @@ public class UserUpdateRequest {
     private String email;
     private String password;
 
+    @JsonProperty("profile_img")
+    private String profileImg;
+
     @JsonProperty("phone")
     private String phone;
 

--- a/src/main/java/org/etmetmy/bn_server/domain/user/dto/response/UserSelfUpdateResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/dto/response/UserSelfUpdateResponse.java
@@ -29,11 +29,15 @@ public class UserSelfUpdateResponse {
     @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
 
+    @JsonProperty("profile_url")
+    private String profileUrl;
+
     public static class Converter {
         public static UserSelfUpdateResponse from(User user) {
             return UserSelfUpdateResponse.builder()
                     .userId(user.getId())
                     .name(user.getName())
+                    .profileUrl(user.getProfileImg())
                     .phone(user.getPhone())
                     .companyName(user.getCompany().getCompanyName())
                     .updatedAt(user.getUpdatedAt())

--- a/src/main/java/org/etmetmy/bn_server/domain/user/entity/User.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/entity/User.java
@@ -64,7 +64,10 @@ public class User extends BaseEntity {
         }
     }
 
-    public void setPassword(String password) {
+    public void updatePassword(String password) {
         this.password = password;
+    }
+    public void updateProfileImage(String ImageUrl){
+        this.profileImg = ImageUrl;
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/user/service/UserService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.etmetmy.bn_server.domain.user.dto.response.*;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
     @Transactional
@@ -33,4 +34,7 @@ public interface UserService {
 
     @Transactional
     UserSelfUpdateResponse updateMyInfo(Long userId, UserSelfUpdateRequest request);
+
+    // 회원정보 수정 - 이미지 업로드
+    UserSelfUpdateResponse updateProfileImage(Long userId, MultipartFile image);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/user/service/UserServiceImpl.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.etmetmy.bn_server.domain.company.entity.Company;
 import org.etmetmy.bn_server.domain.company.repository.CompanyRepository;
 import org.etmetmy.bn_server.domain.company.service.CompanyService;
+import org.etmetmy.bn_server.domain.file.repository.FileRepository;
+import org.etmetmy.bn_server.domain.file.service.FileService;
 import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
 import org.etmetmy.bn_server.domain.user.dto.request.*;
 import org.etmetmy.bn_server.domain.user.dto.entity.UserDto;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.SecureRandom;
 import java.util.List;
@@ -40,12 +43,14 @@ public class UserServiceImpl implements UserService{
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
     private final CompanyService companyService;
+    private final FileService fileService;
     private final PasswordEncoder passwordEncoder;
     private final ProjectMemberRepository projectMemberRepository;
     private final PasswordResetCodeRepository passwordResetCodeRepository;
     private final MailSender mailSender;
 
     private static final int RESET_CODE_EXPIRES_SECONDS = 300;
+    private final FileRepository fileRepository;
 
     // 회원 정보 수정 (Update)
     @Override
@@ -66,10 +71,33 @@ public class UserServiceImpl implements UserService{
         user.updateInfo(request.getName(), request.getEmail(), request.getPhone(), company, request.getRole());
 
         if (request.getPassword() != null && !request.getPassword().isEmpty()) {
-            user.setPassword(passwordEncoder.encode(request.getPassword()));
+            user.updatePassword(passwordEncoder.encode(request.getPassword()));
         }
 
         return user.getId();
+    }
+
+    // 2. 회원 정보 수정 (이미지 업로드)
+    @Override
+    @Transactional
+    public UserSelfUpdateResponse updateProfileImage(Long userId, MultipartFile image){
+        if (image == null || image.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);}
+
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        String oldProfileImg = user.getProfileImg();
+
+        // 1. 새 이미지 먼저 업로드
+        String newProfileImage = fileService.uploadProfileImage(image, userId);
+
+        // 2. 유저에 새 이미지 연결
+        user.updateProfileImage(newProfileImage);
+
+        // 3. 기존 이미지가 있었다면 S3에서 삭제
+        if (oldProfileImg != null) {
+            fileService.removeOldProfileImage(oldProfileImg);
+        }
+        return UserSelfUpdateResponse.Converter.from(user);
     }
 
     // 2. 회원 삭제 (Delete)
@@ -174,7 +202,7 @@ public class UserServiceImpl implements UserService{
         User newUser = UserDto.Converter.toUser(userDto,company);
 
         // 비밀번호 암호화
-        newUser.setPassword(passwordEncoder.encode(userDto.getPassword()));
+        newUser.updatePassword(passwordEncoder.encode(userDto.getPassword()));
 
         Long userId = userRepository.save(newUser).getId();
 
@@ -195,7 +223,7 @@ public class UserServiceImpl implements UserService{
 
         // 3. 비밀번호 암호화 후 변경
         String encodedPassword = passwordEncoder.encode(request.getNewPassword());
-        user.setPassword(encodedPassword);
+        user.updatePassword(encodedPassword);
     }
 
     // 비밀번호 찾기 - 인증 코드 발송
@@ -250,7 +278,7 @@ public class UserServiceImpl implements UserService{
             throw new BusinessException(ErrorCode.INVALID_RESET_CODE);
         }
 
-        user.setPassword(passwordEncoder.encode(newPassword));
+        user.updatePassword(passwordEncoder.encode(newPassword));
 
         resetCode.markAsUsed();
         passwordResetCodeRepository.save(resetCode);
@@ -298,7 +326,4 @@ public class UserServiceImpl implements UserService{
 
         return UserSelfUpdateResponse.Converter.from(user);
     }
-
-
-
 }


### PR DESCRIPTION
## 📄 작업 내용 요약
사용자 프로필 이미지 업로드 기능 구현 및 엔티티 메서드 리팩토링

### 1. 프로필 이미지 업로드 기능 추가

  - Controller: PUT /api/v1/users/profile-image 엔드포인트 추가
  - Service: UserServiceImpl.updateProfileImage() 메서드 구현 
    - 새 이미지 S3 업로드
    - 사용자 엔티티에 새 이미지 URL 저장
    - 기존 이미지 S3에서 삭제

### 2. File Service 확장

  - FileService: 프로필 이미지 관련 메서드 인터페이스 추가
    - uploadProfileImage(): S3에 이미지 업로드 후 URL 반환 (FileServiceImpl.java:376-380)
    - removeOldProfileImage(): 기존 이미지 S3에서 삭제 (FileServiceImpl.java:359-372)

### 3. 엔티티 메서드 리팩토링

  - User 엔티티:
    - setPassword() → updatePassword()로 변경 (User.java:67-69)
    - updateProfileImage() 메서드 추가 (User.java:70-72)
  - Project 엔티티:
    - setProjectImageUrl() → updateProjectImage()로 변경 (Project.java:83)

### 4. Response DTO 개선

  - UserSelfUpdateResponse: profileUrl 필드 추가 

### 5. 회원정보 수정 엔드포인트 수정

  - URL 변경: PUT /users/{userId} → PUT /users (UserController.java:157)
  - 세션에서 사용자 ID 추출하도록 변경
 
<img width="960" height="437" alt="image" src="https://github.com/user-attachments/assets/f7dc282c-7c32-42e8-8795-60455d776a1b" />
<img width="752" height="304" alt="image" src="https://github.com/user-attachments/assets/8051685f-c087-4918-a3b8-13f07658873a" />

## 📎 Issue 275

<!-- closed #275  -->
