### PR TITLE
Refactor/ 파일 휴지통 페이지 위치 이동

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/controller/FileController.java
@@ -67,32 +67,4 @@ public class FileController {
         Long loginUserId = SessionUtil.getLoginUserId(session);
         fileService.deletePostFiles(projectId, postId, fileId, loginUserId);
     }
-
-    //todo: 4. 삭제된 파일 복원 API
-    @Operation(summary = "삭제된 파일 복원", description = "휴지통에 있는 파일을 복원합니다")
-    @PatchMapping("/files/restore")
-    public CommonResponse<FileRestoreResponse> restoreDeletedFiles(
-            @PathVariable Long projectId,
-            @Valid @RequestBody FileRestoreRequest request,
-            HttpSession session)
-    {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-        FileRestoreResponse response = fileService.restoreDeletedFiles(loginUserId, request);
-
-        return CommonResponse.success("삭제된 파일 복원 성공", response);
-    }
-
-    //todo: 5. 삭제된 파일 영구삭제 API
-    @Operation(summary = "삭제된 파일 영구삭제", description = "휴지통에 있는 파일을 DB와 S3에서 완전히 삭제합니다")
-    @DeleteMapping("/files/trash")
-    public CommonResponse<FilePermanentDeleteResponse> deleteDeletedFiles(
-            @PathVariable Long projectId,
-            HttpSession session,
-            @Valid @RequestBody FilePermanentDeleteRequest request)
-    {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-        FilePermanentDeleteResponse response = fileService.hardDeleteFiles(loginUserId, request);
-
-        return CommonResponse.success("삭제된 파일 영구삭제 성공", response);
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/trash/controller/trashController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/trash/controller/trashController.java
@@ -1,0 +1,52 @@
+package org.etmetmy.bn_server.domain.trash.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.file.dto.request.FilePermanentDeleteRequest;
+import org.etmetmy.bn_server.domain.file.dto.request.FileRestoreRequest;
+import org.etmetmy.bn_server.domain.file.dto.response.FilePermanentDeleteResponse;
+import org.etmetmy.bn_server.domain.file.dto.response.FileRestoreResponse;
+import org.etmetmy.bn_server.domain.file.service.FileService;
+import org.etmetmy.bn_server.global.CommonResponse;
+import org.etmetmy.bn_server.global.util.SessionUtil;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Trash", description = "휴지통 페이지 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class trashController {
+
+    private final FileService fileService;
+
+    //todo: 4. 삭제된 파일 복원 API
+    @Operation(summary = "삭제된 파일 복원", description = "휴지통에 있는 파일을 복원합니다")
+    @PatchMapping("/users/projects/{projectId}/files/restore")
+    public CommonResponse<FileRestoreResponse> restoreDeletedFiles(
+            @PathVariable Long projectId,
+            @Valid @RequestBody FileRestoreRequest request,
+            HttpSession session)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        FileRestoreResponse response = fileService.restoreDeletedFiles(loginUserId, request);
+
+        return CommonResponse.success("삭제된 파일 복원 성공", response);
+    }
+
+    //todo: 5. 삭제된 파일 영구삭제 API
+    @Operation(summary = "삭제된 파일 영구삭제", description = "휴지통에 있는 파일을 DB와 S3에서 완전히 삭제합니다")
+    @DeleteMapping("/users/projects/{projectId}/files/trash")
+    public CommonResponse<FilePermanentDeleteResponse> deleteDeletedFiles(
+            @PathVariable Long projectId,
+            HttpSession session,
+            @Valid @RequestBody FilePermanentDeleteRequest request)
+    {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        FilePermanentDeleteResponse response = fileService.hardDeleteFiles(loginUserId, request);
+
+        return CommonResponse.success("삭제된 파일 영구삭제 성공", response);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
파일 도메인에 위치하고 있는 휴지통 페이지 기능을 trashController로 이동했습니다.

## 테스트 완료
- 삭제된 파일 복원 
<img width="1918" height="778" alt="image" src="https://github.com/user-attachments/assets/560b6ced-59f1-4f93-960b-d875a78f286b" />

- 삭제된 파일 영구삭제
<img width="1912" height="676" alt="image" src="https://github.com/user-attachments/assets/868909e2-d1e3-45be-8172-2e41f59cf636" />

## 📎 Issue 282

<!-- closed #282  -->
