### PR TITLE
feat:개발자 시점 대시보드상태 조회 기능 구현

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
-import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestResponse;
 import org.etmetmy.bn_server.domain.dashboard.dto.response.ProjectListResponse;
 import org.etmetmy.bn_server.domain.dashboard.dto.response.DashBoardResponse;
 import org.etmetmy.bn_server.domain.dashboard.service.DashBoardService;

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -20,13 +20,13 @@ public class DashBoardDeveloperController {
 
     private final DashBoardService dashBoardService;
 
-    //todo: 관리자 메인 대시보드 상태 조회 API (STATUS_PENDING인 Post 목록 및 통계)
+    //todo: 개발사 메인 대시보드 상태 조회 API (승인대기 게시글, 반려 게시글, 진행중 프로젝트, 유지보수 프로젝트 갯수 및 목록 조회)
     @Operation(summary = "개발사 대시보드 조회", description = "개발사 메인 대시보드 상태를 조회합니다 (승인 대기 중인 게시글 및 통계)")
     @GetMapping
     public CommonResponse<DashBoardResponse> getStatusDashboard(HttpSession session) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
         DashBoardResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
-        return CommonResponse.success("상태 게시글 조회 성공", result);
+        return CommonResponse.success("개발사 대시보드 상태 조회 성공", result);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -1,0 +1,43 @@
+package org.etmetmy.bn_server.domain.dashboard.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
+import org.etmetmy.bn_server.domain.dashboard.service.DashBoardService;
+import org.etmetmy.bn_server.global.CommonResponse;
+import org.etmetmy.bn_server.global.util.SessionUtil;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard (DEVELOPER)", description = "개발사 대시보드 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/developer/dashboard")
+public class DashBoardDeveloperController {
+
+    private final DashBoardService dashBoardService;
+
+    //todo: 관리자 메인 대시보드 상태 조회 API (STATUS_PENDING인 Post 목록 및 통계)
+    @Operation(summary = "개발사 대시보드 조회", description = "개발사 메인 대시보드 상태를 조회합니다 (승인 대기 중인 게시글 및 통계)")
+    @GetMapping
+    public CommonResponse<ApprovalRequestListResponse> getStatusDashboard(HttpSession session) {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+
+        ApprovalRequestListResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
+        return CommonResponse.success("상태 게시글 조회 성공", result);
+    }
+
+    // todo: 승인대기 화면 리스트들 조회
+    @Operation(summary = "승인 요청 목록 조회", description = "승인 대기 중인 항목들을 조회합니다")
+    @GetMapping("/approval-requests")
+    public CommonResponse<ApprovalRequestListResponse> getApprovalRequests(HttpSession session) {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+
+        ApprovalRequestListResponse result = dashBoardService.getApprovalRequest(loginUserId);
+
+        return CommonResponse.success("승인 요청 알림 조회 성공", result);
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -29,15 +29,4 @@ public class DashBoardDeveloperController {
         ApprovalRequestListResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
         return CommonResponse.success("상태 게시글 조회 성공", result);
     }
-
-    // todo: 승인대기 화면 리스트들 조회
-    @Operation(summary = "승인 요청 목록 조회", description = "승인 대기 중인 항목들을 조회합니다")
-    @GetMapping("/approval-requests")
-    public CommonResponse<ApprovalRequestListResponse> getApprovalRequests(HttpSession session) {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-
-        ApprovalRequestListResponse result = dashBoardService.getApprovalRequest(loginUserId);
-
-        return CommonResponse.success("승인 요청 알림 조회 성공", result);
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -21,7 +21,7 @@ public class DashBoardDeveloperController {
     private final DashBoardService dashBoardService;
 
     //todo: 개발사 메인 대시보드 상태 조회 API (승인대기 게시글, 반려 게시글, 진행중 프로젝트, 유지보수 프로젝트 갯수 및 목록 조회)
-    @Operation(summary = "개발사 대시보드 조회", description = "개발사 메인 대시보드 상태를 조회합니다 (승인 대기 중인 게시글 및 통계)")
+    @Operation(summary = "개발사 대시보드 조회", description = "승인대기 게시글, 반려 게시글, 진행중 프로젝트, 유지보수 프로젝트 갯수 및 목록 조회")
     @GetMapping
     public CommonResponse<DashBoardResponse> getStatusDashboard(HttpSession session) {
         Long loginUserId = SessionUtil.getLoginUserId(session);

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.DashBoardResponse;
 import org.etmetmy.bn_server.domain.dashboard.service.DashBoardService;
 import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.util.SessionUtil;
@@ -23,10 +23,10 @@ public class DashBoardDeveloperController {
     //todo: 관리자 메인 대시보드 상태 조회 API (STATUS_PENDING인 Post 목록 및 통계)
     @Operation(summary = "개발사 대시보드 조회", description = "개발사 메인 대시보드 상태를 조회합니다 (승인 대기 중인 게시글 및 통계)")
     @GetMapping
-    public CommonResponse<ApprovalRequestListResponse> getStatusDashboard(HttpSession session) {
+    public CommonResponse<DashBoardResponse> getStatusDashboard(HttpSession session) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
 
-        ApprovalRequestListResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
+        DashBoardResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
         return CommonResponse.success("상태 게시글 조회 성공", result);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/DashBoardStatusResponseDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/DashBoardStatusResponseDTO.java
@@ -42,6 +42,7 @@ public class DashBoardStatusResponseDTO {
                     .postStageName(post.getStage().getStageName())
                     .requestStatus(requestStatus)
                     .createdAt(post.getCreatedAt())
+                    .projectId(post.getProject().getId())
                     .projectName(post.getProject().getProjectName())
                     .companyName(post.getProject().getCompany().getCompanyName())
                     .build();

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
@@ -20,4 +20,6 @@ public interface DashBoardService {
     DashBoardResponse getCustomerStatusDashboard(Long loginUserId);
 
     ApprovalRequestListResponse getApprovalRequest(Long loginUserId);
+
+    ApprovalRequestListResponse getDeveloperStatusDashboard(Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
@@ -21,5 +21,5 @@ public interface DashBoardService {
 
     ApprovalRequestListResponse getApprovalRequest(Long loginUserId);
 
-    ApprovalRequestListResponse getDeveloperStatusDashboard(Long loginUserId);
+    DashBoardResponse getDeveloperStatusDashboard(Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -140,24 +140,36 @@ public class DashBoardServiceImpl implements DashBoardService {
 
     @Override
     @Transactional(readOnly = true)
-    public ApprovalRequestListResponse getDeveloperStatusDashboard(Long loginUserId) {
+    public DashBoardResponse getDeveloperStatusDashboard(Long loginUserId) {
         // 유저 검증
-        User user = userRepository.findById(loginUserId)
+        userRepository.findById(loginUserId)
                 .orElseThrow(UserNotFoundException::new);
 
         // 개발자가 참여 중인 프로젝트 ID 목록 조회
-        List<Long> projects = projectMemberRepository.findProjectIdsByUserId(user.getId());
+        List<Long> myProjectIds = projectMemberRepository.findProjectIdsByUserId(loginUserId);
 
         // 빈 리스트 처리 (참여 중인 프로젝트가 없는 경우)
-        if (projects.isEmpty()) {
-            return ApprovalRequestListResponse.Converter.of(List.of());
+        if (myProjectIds.isEmpty()) {
+            return DashBoardResponse.Converter.of(List.of(), List.of(), List.of(), List.of());
         }
 
-        // Request가 있는 Post 조회 (참여 중인 프로젝트만)
-        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequestByProjectIds(projects);
-        List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
+        // STATUS_PENDING(요청대기) 상태이면서 참여 중인 프로젝트의 Post 목록
+        List<Post> pendingPosts = postRepository.findPostsWithRequestStatusByProjectIds(RequestStatus.STATUS_PENDING, myProjectIds);
+        List<DashBoardStatusResponseDTO> pendingList = DashBoardStatusResponseDTO.Converter.toPostDTOList(pendingPosts, RequestStatus.STATUS_PENDING);
 
-        // Converter에서 단계별 필터링 및 응답 생성
-        return ApprovalRequestListResponse.Converter.of(allPosts);
+        // STATUS_REJECTED(반려) 상태이면서 참여 중인 프로젝트의 Post 목록
+        List<Post> rejectedPosts = postRepository.findPostsWithRequestStatusByProjectIds(RequestStatus.STATUS_REJECTED, myProjectIds);
+        List<DashBoardStatusResponseDTO> rejectedList = DashBoardStatusResponseDTO.Converter.toPostDTOList(rejectedPosts, RequestStatus.STATUS_REJECTED);
+
+        // 참여 중인 프로젝트 중 진행 중인 Project
+        List<Project> inProgressProjects = projectRepository.findProjectsInProgressByProjectIds(myProjectIds);
+        List<DashBoardStatusResponseDTO> inProgress = DashBoardStatusResponseDTO.Converter.toProejctDTOList(inProgressProjects);
+
+        // 참여 중인 프로젝트 중 유지 보수 Project
+        List<Project> maintenanceProjects = projectRepository.findProjectsMaintenanceByProjectIds(myProjectIds);
+        List<DashBoardStatusResponseDTO> maintenances = DashBoardStatusResponseDTO.Converter.toProejctDTOList(maintenanceProjects);
+
+        // stats와 List를 포함한 wrapper 반환
+        return DashBoardResponse.Converter.of(pendingList, rejectedList, inProgress, maintenances);
     }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -7,6 +7,7 @@ import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
 import org.etmetmy.bn_server.domain.project.entity.Project;
+import org.etmetmy.bn_server.domain.project.entity.ProjectMember;
 import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
 import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
 import org.etmetmy.bn_server.domain.user.entity.User;
@@ -131,6 +132,29 @@ public class DashBoardServiceImpl implements DashBoardService {
 
         // Request가 있는 모든 Post 조회 (상태별, 단계별 카운팅 및 리스트 생성용)
         List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequest();
+        List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
+
+        // Converter에서 단계별 필터링 및 응답 생성
+        return ApprovalRequestListResponse.Converter.of(allPosts);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApprovalRequestListResponse getDeveloperStatusDashboard(Long loginUserId) {
+        // 유저 검증
+        User user = userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 개발자가 참여 중인 프로젝트 ID 목록 조회
+        List<Long> projects = projectMemberRepository.findProjectIdsByUserId(user.getId());
+
+        // 빈 리스트 처리 (참여 중인 프로젝트가 없는 경우)
+        if (projects.isEmpty()) {
+            return ApprovalRequestListResponse.Converter.of(List.of());
+        }
+
+        // Request가 있는 Post 조회 (참여 중인 프로젝트만)
+        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequestByProjectIds(projects);
         List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
 
         // Converter에서 단계별 필터링 및 응답 생성

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/PostRepository.java
@@ -120,4 +120,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p.title FROM Post p WHERE p.id = :postId")
     String findTitleById(@Param("postId") Long postId);
+
+    /**
+     * 특정 프로젝트 목록 내에서 Request가 있는 모든 Post 조회 (개발자용 대시보드)
+     */
+    @Query("SELECT p FROM Post p " +
+            "join fetch p.user u " +
+            "join fetch p.stage s " +
+            "join fetch p.project pr " +
+            "join fetch pr.company c " +
+            "join fetch p.request r " +
+            "WHERE p.request IS NOT NULL " +
+            "AND p.project.id IN :projectIds " +
+            "ORDER BY p.createdAt DESC")
+    List<Post> findAllPostsWithRequestByProjectIds(@Param("projectIds") List<Long> projectIds);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/project/service/ProjectServiceImpl.java
@@ -30,6 +30,7 @@ import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.domain.project.repository.ProjectCheckListRepository;
 import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
 import org.etmetmy.bn_server.domain.user.dto.response.UserSelfUpdateResponse;
+import org.etmetmy.bn_server.domain.user.entity.Role;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.domain.user.repository.UserRepository;
 import org.etmetmy.bn_server.exception.custom.InvalidInputException;


### PR DESCRIPTION
## 📄 작업 내용 요약
개발자 시점의 대시보드 상태(승인대기 게시글, 반려 게시글, 진행중 프로젝트, 유지보수 단계 프로젝트) 조회
---
구현 내용
1. getStatusDashboard 컨트롤러 작성
2. service에서 개발자가 참여중인 프로젝트 Id 목록을 조회하여 response값 반환
<img width="429" height="401" alt="image" src="https://github.com/user-attachments/assets/64c8c706-92e8-4c58-bb01-5d2c22d56097" />

## 📎 Issue 번호

<!-- closed #번호 -->
