### PR TITLE
Bug/ 게시글 완료 API 호출 시 BoardNotFoundException 해결

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -56,26 +56,26 @@ public class PostController {
     @Operation(summary = "게시글 승인", description = "게시글을 승인합니다")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     @PatchMapping("/{postId}/approval")
-    public ResponseEntity<CommonResponse<Object>> approvePost(
+    public CommonResponse<Void> approvePost(
             @PathVariable Long postId,
             @RequestBody @Valid PostApprovalRequest request
     ) {
 
         postService.approvePost(postId, request.getApproverId());
-        return ResponseEntity.ok(CommonResponse.success("게시글 승인 완료"));
+        return CommonResponse.success("게시글 승인 완료", null);
     }
 
     // todo: 게시글 거절 API
     @Operation(summary = "게시글 거절", description = "게시글을 거절합니다 (사유 포함)")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     @PatchMapping("/posts/{postId}/reject")
-    public ResponseEntity<CommonResponse<Object>> rejectPost(
+    public CommonResponse<Void> rejectPost(
             @PathVariable Long postId,
             @RequestBody @Valid PostApprovalRequest request
     ) {
 
         postService.rejectPost(postId, request.getApproverId(), request.getRejectReason());
-        return ResponseEntity.ok(CommonResponse.success("게시글 거절 완료"));
+        return CommonResponse.success("게시글 거절 완료", null);
     }
 
     // todo: 관리자 및 개발사가 게시글 완료하기 버튼 API
@@ -83,12 +83,13 @@ public class PostController {
     @ActivityLogger(targetType = "Post", action = "UPDATE")
     @PatchMapping("/{projectId}/posts/{postId}/completion")
     @HistoryLogger(changeType = ChangeType.UPDATE, targetType = "Post")
-    public void completePost(@PathVariable Long projectId,
-                             @PathVariable Long postId,
+    public CommonResponse<Void> completePost(@PathVariable Long postId,
+                             @PathVariable Long projectId,
                              HttpSession session) {
 
         Long loginUserId = SessionUtil.getLoginUserId(session);
         postService.completePost(projectId, postId, loginUserId);
+        return CommonResponse.success("게시글 완료 성공", null);
     }
 
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -323,23 +323,18 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public void completePost(Long projectId, Long postId, Long loginUserId) {
-        User user = userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
 
-        // ADMIN과 DEVELOPER 권한 확인 (관리자와 개발사 처리 가능)
-        if (user.getRole() != Role.ADMIN && user.getRole() != Role.DEVELOPER) {
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        boolean hasRole = projectMemberRepository.existsByProjectIdAndUserId(projectId, loginUserId);
+
+        boolean isAdmin = user.getRole() == Role.ADMIN;
+        boolean isDeveloperInProject = hasRole && user.getRole() == Role.DEVELOPER;
+
+        // 권한 검증 (관리자와 담당 개발사만 접근가능)
+        if (!isAdmin && !isDeveloperInProject)
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
-        }
 
-        // ADMIN이 아닌 경우에만 프로젝트 멤버 검증
-        if (user.getRole() != Role.ADMIN) {
-            if (!projectMemberRepository.existsByProjectIdAndUserId(projectId, loginUserId)) {
-                throw new BusinessException(ErrorCode.PROJECT_AND_USER_NOT_FOUND);
-            }
-        }
-
-        Post post = postRepository.findById(postId)
-                .orElseThrow(BoardNotFoundException::new);
+        Post post = postRepository.findById(postId).orElseThrow(BoardNotFoundException::new);
 
         // 게시글이 해당 프로젝트에 속하는지 검증
         if (!post.getProject().getId().equals(projectId)) {


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 완료 API 호출 시 BoardNotFoundException 해결했습니다.

### 문제

  게시글 완료 API 호출 시 BoardNotFoundException 발생 (404 에러)
  `POST /api/v1/users/projects/8/posts/22/completion`

### 원인

  HistoryLogAspect의 extractPostId() 메서드가 첫 번째 Long 타입 파라미터를 postId로 인식하는데,
  completePost() 메서드의 파라미터 순서가 (projectId, postId, session)으로 되어있어
  AOP가 projectId(8)을 postId로 잘못 인식

```
  // HistoryLogAspect.java:239-247
  private Long extractPostId(ProceedingJoinPoint joinPoint) {
      for (Object arg : args) {
          if (arg instanceof Long) {
              return (Long) arg;  // ⚠️ 첫 번째 Long 반환 → projectId(8)
          }
      }
  }
```

### ✅ 해결

  PostController.completePost() 메서드의 파라미터 순서를 (postId, projectId, session)으로 변경하여
  다른 메서드들(updatePost, softDeletePost)과 일관성 유지

<img width="2288" height="1488" alt="image" src="https://github.com/user-attachments/assets/e2fbf532-b2de-4bf7-b6b7-cf13f7f93d47" />


## 📎 Issue 318

<!-- closed #318 -->
