### PR TITLE
Refactor/ 게시글 승인, 거절 하기 

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -14,7 +14,6 @@ import org.etmetmy.bn_server.global.CommonResponse;
 import org.etmetmy.bn_server.global.aop.HistoryLogger;
 import org.etmetmy.bn_server.global.util.SessionUtil;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "게시글 관리 API")
@@ -55,13 +54,13 @@ public class PostController {
     // todo: 게시글 승인 API
     @Operation(summary = "게시글 승인", description = "게시글을 승인합니다")
     @ActivityLogger(targetType = "Post", action = "UPDATE")
-    @PatchMapping("/{postId}/approval")
+    @PatchMapping("/posts/{postId}/approval")
     public CommonResponse<Void> approvePost(
             @PathVariable Long postId,
-            @RequestBody @Valid PostApprovalRequest request
+            HttpSession session
     ) {
-
-        postService.approvePost(postId, request.getApproverId());
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        postService.approvePost(postId, loginUserId);
         return CommonResponse.success("게시글 승인 완료", null);
     }
 
@@ -71,10 +70,11 @@ public class PostController {
     @PatchMapping("/posts/{postId}/reject")
     public CommonResponse<Void> rejectPost(
             @PathVariable Long postId,
-            @RequestBody @Valid PostApprovalRequest request
+            @RequestBody @Valid PostApprovalRequest request,
+            HttpSession session
     ) {
-
-        postService.rejectPost(postId, request.getApproverId(), request.getRejectReason());
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+        postService.rejectPost(postId, loginUserId, request.getRejectReason());
         return CommonResponse.success("게시글 거절 완료", null);
     }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
@@ -1,5 +1,6 @@
 package org.etmetmy.bn_server.domain.post.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 
 public class PostApprovalRequest {
 
+    @JsonProperty("reject_reason")
     private String rejectReason;
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
@@ -9,8 +9,5 @@ import lombok.NoArgsConstructor;
 
 public class PostApprovalRequest {
 
-    @NotNull(message = "승인/거절 요청 사용자 ID는 필수입니다.")
-    private Long approverId;
-
     private String rejectReason;
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/entity/Request.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/entity/Request.java
@@ -41,8 +41,8 @@ public class Request extends BaseEntity {
     @Column(name = "reject_reason", length = 255)
     private String rejectReason;
 
-    public void updateStatus(Long replyUserId, RequestStatus status, String rejectReason) {
-        this.replitUserId = replyUserId;
+    public void updateStatus(RequestStatus status, Long loginUserId, String rejectReason) {
+        this.replitUserId = loginUserId;
         this.approveStatus = status;
         this.rejectReason = rejectReason;
         this.replyTime = LocalDateTime.now();

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -13,9 +13,9 @@ import java.util.List;
 public interface PostService {
     PostDetailResponse getPostDetail(Long postId);
 
-    void approvePost(Long postId, Long approvingUserId);
+    void approvePost(Long postId, Long loginUserId);
 
-    void rejectPost(Long postId, Long rejectingUserId, String rejectReason);
+    void rejectPost(Long postId, Long loginUserId, String rejectReason);
 
     PostListByStageResponse getPostListByProjectIdAndFilter(Long projectId, String filter);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -87,7 +87,13 @@ public class PostServiceImpl implements PostService {
 
     // 2. 게시글 승인
     @Transactional
-    public void approvePost(Long postId, Long approvingUserId) {
+    public void approvePost(Long postId, Long loginUserId) {
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+
+        // 권한 검증 (고객사만 승인/거절 가능)
+        if (user.getRole() != Role.CUSTOMER)
+            throw new BusinessException(ErrorCode.REQUEST_PERMISSION_DENIED);
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(BoardNotFoundException::new);
 
@@ -95,12 +101,19 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.REQUEST_PENDING_NOT_FOUND));
 
         // 2. Request 상태를 '승인'으로 업데이트
-        currentRequest.updateStatus(approvingUserId, RequestStatus.STATUS_APPROVED, null);
+        currentRequest.updateStatus(RequestStatus.STATUS_APPROVED, loginUserId, null);
+        requestRepository.save(currentRequest);
     }
 
     // 3. 게시글 거절
     @Transactional
-    public void rejectPost(Long postId, Long rejectingUserId, String rejectReason) {
+    public void rejectPost(Long postId, Long loginUserId, String rejectReason) {
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+
+        // 권한 검증 (고객사만 승인/거절 가능)
+        if (user.getRole() != Role.CUSTOMER)
+            throw new BusinessException(ErrorCode.REQUEST_PERMISSION_DENIED);
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(BoardNotFoundException::new);
 
@@ -108,7 +121,8 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.REQUEST_PENDING_NOT_FOUND));
 
         // 2. Request 상태를 '거절'로 업데이트
-        currentRequest.updateStatus(rejectingUserId, RequestStatus.STATUS_REJECTED, rejectReason);
+        currentRequest.updateStatus(RequestStatus.STATUS_REJECTED, loginUserId, rejectReason);
+        requestRepository.save(currentRequest);
     }
 
     @Override

--- a/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
+++ b/src/main/java/org/etmetmy/bn_server/exception/code/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     BOARD_INVALID_FILTER(400,"B005", "유효하지 않은 게시글 필터입니다."),
     POST_PROJECT_MISMATCH(400, "P014", "게시글이 해당 프로젝트에 속하지 않습니다."),
     DELETED_BOARD_ACCESS_DENIED(403,"D006","삭제된 게시글에 접근 권한이 없습니다."),
+    REQUEST_PERMISSION_DENIED(403, "R003", "요청 승인/거절 권한이 없습니다."),
 
     // 댓글 관련 에러
     BOARD_COMMENT_NOT_FOUND(404, "C001", "댓글을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 승인/거절 API 리팩토링했습니다.

### 1. API 엔드포인트 변경

  - 승인 API 경로 수정:` /{postId}/approval `→ `/posts/{postId}/approval
`
### 2. Request DTO 구조 개선 

  - 제거:` approverId `필드 삭제 (클라이언트가 승인자 ID를 보내지 않도록)
  - 유지: rejectReason 필드만 남김 (거절 사유용)
  - `@JsonProperty("reject_reason") `추가 (스네이크 케이스 지원)

### 3. 컨트롤러 개선 

```
  // 승인 API - approverId를 request에서 받지 않고 세션에서 추출
  approvePost(@PathVariable Long postId, HttpSession session)

  // 거절 API - approverId를 request에서 받지 않고 세션에서 추출  
  rejectPost(@PathVariable Long postId, @RequestBody PostApprovalRequest request, HttpSession session)
```

### 4. 서비스 레이어 강화 

  - 권한 검증 추가: 고객사(CUSTOMER) 권한만 승인/거절 가능
  - 명시적 저장: requestRepository.save() 호출 추가
  - 파라미터 순서 정리: updateStatus(RequestStatus, loginUserId, rejectReason)

### 5. 엔티티 메서드 개선

  ```
// Before: updateStatus(Long replyUserId, RequestStatus status, String rejectReason)
  // After:  updateStatus(RequestStatus status, Long loginUserId, String rejectReason)
```

### 6. 에러 코드 추가 (ErrorCode.java:30)

  - REQUEST_PERMISSION_DENIED(403, "R003", "요청 승인/거절 권한이 없습니다.")

<img width="1115" height="367" alt="image" src="https://github.com/user-attachments/assets/a6bd6830-bd43-412d-89e4-f301a9a8a5b2" />
<img width="2012" height="162" alt="image" src="https://github.com/user-attachments/assets/ead4d7fd-c85c-4d5b-a166-981ac26d6b75" />

## 📎 Issue 321
<!-- closed #321  -->
