### PR TITLE
refactoring/게시글 거절 api에 링크와 파일 첨부 추가

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/entity/File.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.domain.user.entity.User;
@@ -42,6 +43,10 @@ public class File extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_check_list_id")
     private ProjectCheckList projectCheckList;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id")
+    private Request request;
 
     @Column(name = "s3_file_title", nullable = false, length = 255)
     private String s3FileTitle; // UUID_파일명
@@ -93,25 +98,32 @@ public class File extends BaseEntity {
     }
 
     // 공통 내부 처리
-    private void attach(Post post, Comment comment, ProjectCheckList projectCheckList, Long uploadedBy) {
+    private void attach(Post post, Comment comment, ProjectCheckList projectCheckList, Request request, Long uploadedBy) {
         this.post = post;
         this.comment = comment;
         this.projectCheckList = projectCheckList;
+        this.request = request;
         this.isTemp = false;
         this.uploadedBy = uploadedBy;
     }
 
     // 게시글에 연결
     public void attachToPost(Post post, Long uploadedBy) {
-        attach(post, null,null, uploadedBy);
+        attach(post, null, null, null, uploadedBy);
     }
 
     // 댓글에 연결
     public void attachToComment(Comment comment, Long uploadedBy) {
-        attach(null, comment, null, uploadedBy);
+        attach(null, comment, null, null, uploadedBy);
     }
 
     public void attachToProjectCheckList(ProjectCheckList projectCheckList, Long uploadedBy) {
-        attach(null, null, projectCheckList, uploadedBy);
+        attach(null, null, projectCheckList, null, uploadedBy);
     }
+
+    public void attachToRequest(Request request, Long uploadedBy) {
+        attach(null, null, null, request, uploadedBy);
+    }
+
+
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileService.java
@@ -7,6 +7,7 @@ import org.etmetmy.bn_server.domain.file.dto.request.FileRestoreRequest;
 import org.etmetmy.bn_server.domain.file.dto.response.*;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
@@ -45,6 +46,9 @@ public interface FileService {
 
     // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 ProjectCheckList에 저장
     void saveFiles(ProjectCheckList projectCheckList, List<Long> fileIds, Long loginUserId);
+
+    // S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 request에 저장
+    void saveFiles(Request request, List<Long> fileIds, Long loginUserId);
 
     // 삭제된 파일 복원
     public FileRestoreResponse restoreDeletedFiles(Long loginUserId, @Valid FileRestoreRequest request);

--- a/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/file/service/FileServiceImpl.java
@@ -10,6 +10,7 @@ import org.etmetmy.bn_server.domain.file.dto.response.*;
 import org.etmetmy.bn_server.domain.file.entity.File;
 import org.etmetmy.bn_server.domain.file.repository.FileRepository;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.post.repository.PostRepository;
 import org.etmetmy.bn_server.domain.post.service.PostServiceImpl;
 import org.etmetmy.bn_server.domain.project.entity.Project;
@@ -67,7 +68,7 @@ public class FileServiceImpl implements FileService {
     // 1. 삭제된 파일 목록 조회
     @Override
     @Transactional
-    public List<FileTrashResponse> getDeletedFiles(Long loginUserId, Long projectId){
+    public List<FileTrashResponse> getDeletedFiles(Long loginUserId, Long projectId) {
 
         // 권한 검증 (관리자와 담당 개발사만 접근가능)
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
@@ -201,7 +202,7 @@ public class FileServiceImpl implements FileService {
     // 5. 삭제된 파일 복원
     @Override
     @Transactional
-    public FileRestoreResponse restoreDeletedFiles(Long loginUserId, @Valid FileRestoreRequest request){
+    public FileRestoreResponse restoreDeletedFiles(Long loginUserId, @Valid FileRestoreRequest request) {
 
         // 1. 권한 검증 (관리자만)
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
@@ -382,27 +383,35 @@ public class FileServiceImpl implements FileService {
     @Override
     @Transactional
     public void saveFiles(Post post, List<Long> fileIds, Long loginUserId) {
-        saveFilesInternal(post, null, null, fileIds, loginUserId);
+        saveFilesInternal(post, null, null, null,fileIds, loginUserId);
     }
 
     // 12. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
     @Override
     @Transactional
     public void saveFiles(Comment comment, List<Long> fileIds, Long loginUserId) {
-        saveFilesInternal(null, comment, null, fileIds, loginUserId);
+        saveFilesInternal(null, comment, null,null, fileIds, loginUserId);
     }
 
-    // 13. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post에 저장
+    // 13. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 ProjectCheckList에 저장
     @Override
     @Transactional
     public void saveFiles(ProjectCheckList projectCheckList, List<Long> fileIds, Long loginUserId) {
-        saveFilesInternal(null, null, projectCheckList, fileIds, loginUserId);
+        saveFilesInternal(null, null, projectCheckList, null,fileIds, loginUserId);
+    }
+
+    // 14. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 request에 저장
+    @Override
+    public void saveFiles(Request request, List<Long> fileIds, Long loginUserId) {
+        saveFilesInternal(null, null, null, request, fileIds, loginUserId);
+
     }
 
     // 14. S3 업로드 결과로 받은 파일 정보를 기반으로 File 엔티티를 생성하여 Post/Comment에 저장
-    private void saveFilesInternal(Post post, Comment comment, ProjectCheckList projectCheckList, List<Long> fileIds, Long loginUserId) {
+    private void saveFilesInternal(Post post, Comment comment, ProjectCheckList projectCheckList, Request rejectRequest, List<Long> fileIds, Long loginUserId) {
         if (fileIds == null || fileIds.isEmpty()) {
-            return;}
+            return;
+        }
 
         List<File> tempFiles = fileRepository.findAllById(fileIds)
                 .stream()
@@ -426,12 +435,14 @@ public class FileServiceImpl implements FileService {
         }
 
         for (File file : tempFiles) {
-            if (comment == null && projectCheckList == null) {
+            if (comment == null && projectCheckList == null && rejectRequest == null) {
                 file.attachToPost(post, loginUserId);
-            } else if (post == null && projectCheckList == null) {
+            } else if (post == null && projectCheckList == null && rejectRequest == null) {
                 file.attachToComment(comment, loginUserId);
-            } else {
+            } else if (post == null && comment == null && rejectRequest == null) {
                 file.attachToProjectCheckList(projectCheckList, loginUserId);
+            } else {
+                file.attachToRequest(rejectRequest, loginUserId);
             }
 
             // 파일 히스토리 이벤트 발행 (CREATE)
@@ -446,7 +457,7 @@ public class FileServiceImpl implements FileService {
     // 15. 이미지 url로 기존 이미지 삭제 (S3 + DB)
     @Override
     @Transactional
-    public void removeOldImage(String oldImageUrl){
+    public void removeOldImage(String oldImageUrl) {
 
         // S3 key 추출
         String key = getKeyFromFileUrls(oldImageUrl);
@@ -462,7 +473,7 @@ public class FileServiceImpl implements FileService {
     // 16. 프로필 이미지 수정 - 새 이미지 업로드 후 S3 이미지 URL 저장
     @Override
     @Transactional
-    public String uploadProfileImage(MultipartFile image, Long userId){
+    public String uploadProfileImage(MultipartFile image, Long userId) {
         S3UploadResult uploadResult = uploadToS3(image);
 
         return uploadResult.getFileUrl();

--- a/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/dto/LinkCreateRequest.java
@@ -8,6 +8,7 @@ import org.etmetmy.bn_server.domain.checkList.entity.CheckList;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 
 import java.util.List;
@@ -24,12 +25,13 @@ public class LinkCreateRequest {
 
     public static class Converter {
         // 공통 생성 로직
-        private static Link buildLink(Post post, Comment comment, ProjectCheckList projectCheckList, String url, Long uploadedBy) {
+        private static Link buildLink(Post post, Comment comment, ProjectCheckList projectCheckList, Request request, String url, Long uploadedBy) {
             return Link.builder()
                     .post(post)
                     .comment(comment)
                     .projectCheckList(projectCheckList)
                     .linkUrl(url)
+                    .request(request)
                     .uploadedBy(uploadedBy)
                     .isDeleted(false)
                     .build();
@@ -37,37 +39,49 @@ public class LinkCreateRequest {
 
         // post 단건
         public static Link toEntity(Post post, String url, Long uploadedBy) {
-            return buildLink(post, null, null, url, uploadedBy);
+            return buildLink(post, null, null, null, url, uploadedBy);
         }
 
         // comment 단건
         public static Link toEntity(Comment comment, String url, Long uploadedBy) {
-            return buildLink(null, comment,null, url, uploadedBy);
+            return buildLink(null, comment, null, null, url, uploadedBy);
         }
 
         // checkList 단건
         public static Link toEntity(ProjectCheckList projectCheckList, String url, Long uploadedBy) {
-            return buildLink(null, null, projectCheckList, url, uploadedBy);
+            return buildLink(null, null, projectCheckList, null, url, uploadedBy);
+        }
+
+        // request 단건
+        public static Link toEntity(Request request, String url, Long uploadedBy) {
+            return buildLink(null, null, null, request, url, uploadedBy);
         }
 
         // post 리스트
         public static List<Link> toEntity(Post post, List<String> linkUrls, Long uploadedBy) {
             return linkUrls.stream()
-                    .map(url -> buildLink(post, null,null, url, uploadedBy))
+                    .map(url -> buildLink(post, null, null, null, url, uploadedBy))
                     .collect(Collectors.toList());
         }
 
         // comment 리스트
         public static List<Link> toEntity(Comment comment, List<String> linkUrls, Long uploadedBy) {
             return linkUrls.stream()
-                    .map(url -> buildLink(null, comment,null, url, uploadedBy))
+                    .map(url -> buildLink(null, comment, null, null, url, uploadedBy))
                     .collect(Collectors.toList());
         }
 
         // projectCheckList 리스트
         public static List<Link> toEntity(ProjectCheckList projectCheckList, List<String> linkUrls, Long uploadedBy) {
             return linkUrls.stream()
-                    .map(url -> buildLink(null,null, projectCheckList, url, uploadedBy))
+                    .map(url -> buildLink(null, null, projectCheckList, null, url, uploadedBy))
+                    .collect(Collectors.toList());
+        }
+
+        // request 리스트
+        public static List<Link> toEntity(Request request, List<String> linkUrls, Long uploadedBy) {
+            return linkUrls.stream()
+                    .map(url -> buildLink(null, null, null, request, url, uploadedBy))
                     .collect(Collectors.toList());
         }
     }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/entity/Link.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/entity/Link.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
 
@@ -36,6 +37,10 @@ public class Link extends BaseEntity { //다른 패키지에서 접근
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_check_list_id")
     private ProjectCheckList projectCheckList;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id")
+    private Request request;
 
     @Column(name = "link_url", nullable = false, length = 500)
     private String linkUrl;

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkService.java
@@ -2,6 +2,7 @@ package org.etmetmy.bn_server.domain.link.service;
 
 import org.etmetmy.bn_server.domain.comment.entity.Comment;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 
 import java.util.List;
@@ -17,4 +18,6 @@ public interface LinkService {
     // 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 프로젝트 체크리스트에 저장
     public void saveLinks(ProjectCheckList projectCheckList, List<String> linkUrls, Long uploadedBy);
 
+    // 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 request에 저장
+    public void saveLinks(Request request, List<String> linkUrls, Long uploadedBy);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/link/service/LinkServiceImpl.java
@@ -9,6 +9,7 @@ import org.etmetmy.bn_server.domain.link.dto.LinkCreateRequest;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.project.entity.Project;
 import org.etmetmy.bn_server.domain.project.entity.ProjectCheckList;
 import org.etmetmy.bn_server.global.util.IpAddressUtil;
@@ -30,22 +31,28 @@ public class LinkServiceImpl implements LinkService {
     // 1. 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 게시글에 한 번에 저장
     @Transactional
     public void saveLinks(Post post, List<String> linkUrls, Long uploadedBy) {
-        saveLinksInternal(post, null, null, linkUrls, uploadedBy);
+        saveLinksInternal(post, null, null, null, linkUrls, uploadedBy);
     }
 
     // 2. 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 댓글에 한 번에 저장
     @Transactional
     public void saveLinks(Comment comment, List<String> linkUrls, Long uploadedBy) {
-        saveLinksInternal(null, comment, null, linkUrls, uploadedBy);
+        saveLinksInternal(null, comment, null, null, linkUrls, uploadedBy);
     }
 
     @Override
     public void saveLinks(ProjectCheckList projectCheckList, List<String> linkUrls, Long uploadedBy) {
-        saveLinksInternal(null, null, projectCheckList, linkUrls, uploadedBy);
+        saveLinksInternal(null, null, projectCheckList, null, linkUrls, uploadedBy);
     }
 
+    @Override
+    public void saveLinks(Request request, List<String> linkUrls, Long uploadedBy) {
+        saveLinksInternal(null, null, null, request, linkUrls, uploadedBy);
+    }
+
+
     // 링크 URL 리스트를 받아서 Link 엔티티로 변환하고 게시글/댓글에 한 번에 저장
-    private void saveLinksInternal(Post post, Comment comment, ProjectCheckList projectCheckList, List<String> linkUrls, Long uploadedBy) {
+    private void saveLinksInternal(Post post, Comment comment, ProjectCheckList projectCheckList, Request reqeust, List<String> linkUrls, Long uploadedBy) {
         if (linkUrls == null || linkUrls.isEmpty()) {
             return;
         }
@@ -63,12 +70,15 @@ public class LinkServiceImpl implements LinkService {
         }
 
         List<Link> newLinks;
-        if (comment == null && projectCheckList == null) {
+        if (comment == null && projectCheckList == null && reqeust == null) {
             newLinks = LinkCreateRequest.Converter.toEntity(post, linkUrls, uploadedBy);
-        } else if(post == null && projectCheckList == null) {
+        } else if (post == null && projectCheckList == null && reqeust == null) {
             newLinks = LinkCreateRequest.Converter.toEntity(comment, linkUrls, uploadedBy);
-        }else{
+
+        } else if (post == null && reqeust == null && comment == null) {
             newLinks = LinkCreateRequest.Converter.toEntity(projectCheckList, linkUrls, uploadedBy);
+        } else {
+            newLinks = LinkCreateRequest.Converter.toEntity(reqeust, linkUrls, uploadedBy);
         }
         List<Link> savedLinks = linkRepository.saveAll(newLinks);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/controller/PostController.java
@@ -74,7 +74,7 @@ public class PostController {
             HttpSession session
     ) {
         Long loginUserId = SessionUtil.getLoginUserId(session);
-        postService.rejectPost(postId, loginUserId, request.getRejectReason());
+        postService.rejectPost(postId, loginUserId, request);
         return CommonResponse.success("게시글 거절 완료", null);
     }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostApprovalRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 
@@ -12,4 +14,10 @@ public class PostApprovalRequest {
 
     @JsonProperty("reject_reason")
     private String rejectReason;
+
+    // S3에 업로드된 파일 정보 목록 (선택 사항)
+    private List<Long> fileIds;
+
+    // 링크 URL 목록 (선택 사항)
+    private List<String> linkUrls;
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostService.java
@@ -1,10 +1,7 @@
 package org.etmetmy.bn_server.domain.post.service;
 
 import jakarta.validation.Valid;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostPermanentDeleteRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.*;
 import org.etmetmy.bn_server.domain.post.dto.response.*;
 import org.etmetmy.bn_server.domain.project.dto.response.ProjectRestoreResponse;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +13,7 @@ public interface PostService {
 
     void approvePost(Long postId, Long loginUserId);
 
-    void rejectPost(Long postId, Long loginUserId, String rejectReason);
+    void rejectPost(Long postId, Long loginUserId, @Valid PostApprovalRequest reject);
 
     PostListByStageResponse getPostListByProjectIdAndFilter(Long projectId, String filter);
 

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -119,7 +119,7 @@ public class PostServiceImpl implements PostService {
         Request currentRequest = requestRepository.findByPostPostIdAndApproveStatus(post.getPostId(), RequestStatus.STATUS_PENDING)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REQUEST_PENDING_NOT_FOUND));
 
-        // 2. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 게시글과 연동
+        // 2. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 request와 연동
         linkService.saveLinks(currentRequest, reject.getLinkUrls(), loginUserId);
 
         // 3. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -15,10 +15,7 @@ import org.etmetmy.bn_server.domain.link.dto.LinkInfoDTO;
 import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.link.repository.LinkRepository;
 import org.etmetmy.bn_server.domain.link.service.LinkService;
-import org.etmetmy.bn_server.domain.post.dto.request.PostCreateRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostPermanentDeleteRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostRestoreRequest;
-import org.etmetmy.bn_server.domain.post.dto.request.PostUpdateRequest;
+import org.etmetmy.bn_server.domain.post.dto.request.*;
 import org.etmetmy.bn_server.domain.post.dto.response.*;
 import org.etmetmy.bn_server.domain.post.entity.*;
 import org.etmetmy.bn_server.domain.post.repository.PostNumberCounterRepository;
@@ -109,7 +106,7 @@ public class PostServiceImpl implements PostService {
 
     // 3. 게시글 거절
     @Transactional
-    public void rejectPost(Long postId, Long loginUserId, String rejectReason) {
+    public void rejectPost(Long postId, Long loginUserId, PostApprovalRequest reject) {
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
 
         // 권한 검증 (고객사만 승인/거절 가능)
@@ -122,8 +119,14 @@ public class PostServiceImpl implements PostService {
         Request currentRequest = requestRepository.findByPostPostIdAndApproveStatus(post.getPostId(), RequestStatus.STATUS_PENDING)
                 .orElseThrow(() -> new BusinessException(ErrorCode.REQUEST_PENDING_NOT_FOUND));
 
-        // 2. Request 상태를 '거절'로 업데이트
-        currentRequest.updateStatus(RequestStatus.STATUS_REJECTED, loginUserId, rejectReason);
+        // 2. 링크 저장: 전달받은 링크 URL 리스트를 Link 엔티티로 변환 후 게시글과 연동
+        linkService.saveLinks(currentRequest, reject.getLinkUrls(), loginUserId);
+
+        // 3. 임시 파일 연결: 프론트에서 전달받은 fileIds를 기준으로 DB 에서 임시 파일(isTemp=true)을 조회
+        fileService.saveFiles(currentRequest, reject.getFileIds(), loginUserId);
+
+        // 4. Request 상태를 '거절'로 업데이트
+        currentRequest.updateStatus(RequestStatus.STATUS_REJECTED, loginUserId, reject.getRejectReason());
         requestRepository.save(currentRequest);
     }
 
@@ -187,7 +190,8 @@ public class PostServiceImpl implements PostService {
 
         Post parent = null;
         if (requestDto.getParentId() != null) {
-            parent = postRepository.findById(requestDto.getParentId()).orElseThrow(BoardNotFoundException::new);}
+            parent = postRepository.findById(requestDto.getParentId()).orElseThrow(BoardNotFoundException::new);
+        }
 
         // 1. 게시글 저장: DTO를 엔티티로 변환 후 DB에 저장, ID 발급
         Post post = PostCreateRequest.Converter.toEntity(project, user, stage, postNumber, parent, requestDto);
@@ -222,7 +226,7 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(BoardNotFoundException::new);
 
         // 2. 작성자 권한 검증 (작성자만 수정 가능)
-        if(!post.getUser().getId().equals(loginUserId)){
+        if (!post.getUser().getId().equals(loginUserId)) {
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
         }
 
@@ -364,15 +368,15 @@ public class PostServiceImpl implements PostService {
     // 게시글 삭제 (soft delete)
     @Override
     @Transactional
-    public void softDeletePost(Long postId, Long userId){
+    public void softDeletePost(Long postId, Long userId) {
 
         // 1. 엔티티 조회
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BOARD_POST_NOT_FOUND));
-        List<Comment>  comments = commentRepository.findAllByPostId(post.getPostId());
+        List<Comment> comments = commentRepository.findAllByPostId(post.getPostId());
 
         // 2. 작성자 권한 검증 (작성자만 삭제 가능)
-        if(!post.getUser().getId().equals(userId)){
+        if (!post.getUser().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.BOARD_PERMISSION_DENIED);
         }
 
@@ -394,7 +398,7 @@ public class PostServiceImpl implements PostService {
     // 게시글 복원
     @Override
     @Transactional
-    public PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request){
+    public PostRestoreResponse restoreDeletedPost(Long loginUserId, PostRestoreRequest request) {
 
         // 1. 권한 검증 (관리자만)
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
@@ -439,7 +443,7 @@ public class PostServiceImpl implements PostService {
     // 게시글 영구삭제 (hard delete)
     @Override
     @Transactional
-    public PostPermanentDeleteResponse deleteDeletedPost(Long loginUserId, @Valid PostPermanentDeleteRequest request){
+    public PostPermanentDeleteResponse deleteDeletedPost(Long loginUserId, @Valid PostPermanentDeleteRequest request) {
 
         // 1. 삭제 요청한 게시글 ID 목록 조회
         List<Long> postIds = request.getPostIds();
@@ -453,7 +457,8 @@ public class PostServiceImpl implements PostService {
         // 3. 삭제 여부 체크
         posts.forEach(post -> {
             if (!post.getIsDeleted()) {
-                throw new BusinessException(ErrorCode.BOARD_NOT_DELETED);}
+                throw new BusinessException(ErrorCode.BOARD_NOT_DELETED);
+            }
         });
 
         // 4. S3 파일 삭제
@@ -469,7 +474,7 @@ public class PostServiceImpl implements PostService {
     // 삭제된 프로젝트 조회
     @Override
     @Transactional
-    public List<PostTrashResponse> getDeletedPosts(Long loginUserId, Long projectId){
+    public List<PostTrashResponse> getDeletedPosts(Long loginUserId, Long projectId) {
 
         // 권한 검증 (관리자와 담당 개발사만 접근가능)
         User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);


### PR DESCRIPTION
## 📄 작업 내용 요약
게시글 거절 api 호출 시
request에 파일첨부와 링크 첨부 기능 추가
<img width="608" height="575" alt="image" src="https://github.com/user-attachments/assets/425f6275-e742-4577-a0c5-15c1dcda360c" />

성공
<img width="764" height="126" alt="image" src="https://github.com/user-attachments/assets/2eeea383-fc1e-4e37-a5bc-f71109130755" />


file 엔티티에 request 컬럼 추가
<img width="437" height="91" alt="image" src="https://github.com/user-attachments/assets/f767f56b-0885-475f-b473-b7da9bc946e8" />

fileServiceImpl에 request에 대한 메서드 추가
<img width="636" height="116" alt="image" src="https://github.com/user-attachments/assets/ffc3c9b5-e093-426d-be56-fa09f1bdcc96" />

link 엔티티에 request 컬럼 추가
<img width="440" height="166" alt="image" src="https://github.com/user-attachments/assets/e1d4ed1c-50cd-4928-afac-5de951a124f1" />

linkServiceImpl에 request에 대한 메서드 추가
<img width="654" height="98" alt="image" src="https://github.com/user-attachments/assets/b2428a38-9920-415c-bab2-2a67ef5f2f1c" />


PostApprovalReuest 클래스 수정
<img width="336" height="305" alt="image" src="https://github.com/user-attachments/assets/8ec2b790-a673-425e-bd47-fb66afd355a1" />


## 📎 Issue 번호

<!-- closed #번호 -->
