### PR TITLE
Feature/ 개별 프로젝트 승인요청 알림 조회

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardController.java
@@ -45,27 +45,4 @@ public class DashBoardController {
 
         return CommonResponse.success("프로젝트 목록 조회 성공", response);
     }
-
-    // todo: 개별 프로젝트 승인대기 화면 리스트들 조회
-    @Operation(summary = "개별 프로젝트 승인 요청 목록 조회", description = "개별 프로젝트 승인 대기 중인 항목들을 조회합니다")
-    @GetMapping("/projects/{projectId}/approval-requests")
-    public CommonResponse<ApprovalRequestListResponse> getApprovalRequests(
-            @PathVariable Long projectId, HttpSession session) {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-
-        ApprovalRequestListResponse result = dashBoardService.getApprovalRequest(projectId, loginUserId);
-
-        return CommonResponse.success("승인 요청 알림 조회 성공", result);
-    }
-    // todo: 전체 프로젝트승인대기 화면 리스트들 조회
-    @Operation(summary = "전체 프로젝트 승인 요청 목록 조회", description = "전체 프로젝트 승인 대기 중인 항목들을 조회합니다")
-    @GetMapping("/approval-requests")
-    public CommonResponse<ApprovalRequestListResponse> getTotalApprovalRequests(HttpSession session) {
-            Long loginUserId = SessionUtil.getLoginUserId(session);
-
-            ApprovalRequestListResponse result = dashBoardService.getAdminApprovalRequest(loginUserId);
-
-            return CommonResponse.success("승인 요청 알림 조회 성공", result);
-        }
-
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardCustomerController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardCustomerController.java
@@ -46,16 +46,4 @@ public class DashBoardCustomerController {
 
         return CommonResponse.success("프로젝트 목록 조회 성공", response);
     }
-
-    // todo: 고객사 승인대기 화면 리스트들 조회
-    @Operation(summary = "고객사 게시글 승인 요청 목록 조회", description = "승인 요청한 게시글 목록들을 조회합니다")
-    @GetMapping("/projects/{projectId}/approval-requests")
-    public CommonResponse<ApprovalRequestListResponse> getApprovalRequests(
-            @PathVariable Long projectId, HttpSession session) {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-
-        ApprovalRequestListResponse result = dashBoardService.getApprovalRequest(projectId, loginUserId);
-
-        return CommonResponse.success("고객사 승인 요청 알림 조회 성공", result);
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/controller/DashBoardDeveloperController.java
@@ -31,16 +31,4 @@ public class DashBoardDeveloperController {
         DashBoardResponse result = dashBoardService.getDeveloperStatusDashboard(loginUserId);
         return CommonResponse.success("개발사 대시보드 상태 조회 성공", result);
     }
-
-    // todo: 개발사 승인대기 화면 리스트들 조회
-    @Operation(summary = "개발사 게시글 승인 요청 목록 조회", description = "승인 요청한 게시글 목록들을 조회합니다")
-    @GetMapping("/projects/{projectId}/approval-requests")
-    public CommonResponse<ApprovalRequestListResponse> getApprovalRequests(
-            @PathVariable Long projectId, HttpSession session) {
-        Long loginUserId = SessionUtil.getLoginUserId(session);
-
-        ApprovalRequestListResponse result = dashBoardService.getApprovalRequest(projectId, loginUserId);
-
-        return CommonResponse.success("개발사 승인 요청 알림 조회 성공", result);
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
@@ -1,6 +1,7 @@
 package org.etmetmy.bn_server.domain.dashboard.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,20 +19,21 @@ import java.util.stream.Collectors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApprovalRequestResponse {
 
-    // 게시글 관련
-    private Long postId;                    // 게시글 id
-    private String postTitle;               // 게시글 제목
-    private LocalDateTime createdAt;        // 게시글 생성일자
-    private RequestStatus requestStatus;    // 게시글 요청상태
-    private String postStageName;           // 게시글 진행단계
+    @JsonProperty("post_id")
+    private Long postId;
 
-    // 프로젝트 관련
-    private String projectName;             // 프로젝트 이름
+    @JsonProperty("post_title")
+    private String postTitle;
 
-    // 회사 관련
-    private String companyName;             // 회사 이름
+    @JsonProperty("")
+    private LocalDateTime createdAt;
+    private RequestStatus requestStatus;
+    private String postStageName;
 
-    // 승인 여부
+    private String projectName;
+
+    private String companyName;
+
     private String approveStatus;
 
     public static class Converter {

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardService.java
@@ -1,6 +1,5 @@
 package org.etmetmy.bn_server.domain.dashboard.service;
 
-import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
 import org.etmetmy.bn_server.domain.dashboard.dto.response.ProjectListResponse;
 import java.util.List;
 import org.etmetmy.bn_server.domain.dashboard.dto.response.DashBoardResponse;
@@ -19,8 +18,4 @@ public interface DashBoardService {
     DashBoardResponse getCustomerStatusDashboard(Long loginUserId);
 
     DashBoardResponse getDeveloperStatusDashboard(Long loginUserId);
-
-    ApprovalRequestListResponse getApprovalRequest(Long projectId, Long loginUserId);
-
-    ApprovalRequestListResponse getAdminApprovalRequest(Long loginUserId);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/service/DashBoardServiceImpl.java
@@ -161,45 +161,4 @@ public class DashBoardServiceImpl implements DashBoardService {
         // stats와 List를 포함한 wrapper 반환
         return DashBoardResponse.Converter.of(pendingList, rejectedList, inProgress, maintenances);
     }
-
-    @Override
-    @Transactional(readOnly = true)
-    public ApprovalRequestListResponse getApprovalRequest(Long projectId, Long loginUserId) {
-        // 유저 검증
-        User user = userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
-
-        // 프로젝트 존재 여부 및 접근 권한 확인 (ADMIN은 모든 프로젝트 접근 가능)
-        if (user.getRole() != Role.ADMIN) {
-            if (!projectMemberRepository.existsByProjectIdAndUserId(projectId, user.getId())) {
-                throw new BusinessException(ErrorCode.PROJECT_AND_USER_NOT_FOUND);
-            }
-        }
-
-        // 프로젝트 존재 여부 확인
-        projectRepository.findById(projectId)
-                .orElseThrow(ProjectNotFoundException::new);
-
-        // 특정 프로젝트의 Request가 있는 Post 조회
-        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequestByProjectIds(List.of(projectId));
-        List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
-
-        // Converter에서 단계별 필터링 및 응답 생성
-        return ApprovalRequestListResponse.Converter.of(allPosts);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public ApprovalRequestListResponse getAdminApprovalRequest(Long loginUserId) {
-        // 유저 검증
-        userRepository.findById(loginUserId)
-                .orElseThrow(UserNotFoundException::new);
-
-        // Request가 있는 모든 Post 조회 (상태별, 단계별 카운팅 및 리스트 생성용)
-        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequest();
-        List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
-
-        // Converter에서 단계별 필터링 및 응답 생성
-        return ApprovalRequestListResponse.Converter.of(allPosts);
-    }
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostCreateRequest.java
@@ -65,7 +65,7 @@ public class PostCreateRequest {
          * @return Request 엔티티 또는 null (승인요청이 없는 경우)
          */
         public static Request toRequestEntity(
-                PostCreateRequest requestDto, Post post, Long requestUserId) {
+                PostCreateRequest requestDto, Post post, User user) {
 
             if (!Boolean.TRUE.equals(requestDto.getRequestApproval())) {
                 return null;
@@ -73,7 +73,7 @@ public class PostCreateRequest {
 
             return Request.builder()
                     .post(post)
-                    .requestUserId(requestUserId)
+                    .responder(user)
                     .approveStatus(RequestStatus.STATUS_PENDING)
                     .build();
         }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/PostUpdateRequest.java
@@ -10,6 +10,7 @@ import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 import org.etmetmy.bn_server.domain.post.entity.Stage;
+import org.etmetmy.bn_server.domain.user.entity.User;
 
 import java.util.List;
 
@@ -64,7 +65,7 @@ public class PostUpdateRequest {
         }
 
         public static Request toRequestEntity(
-                PostUpdateRequest requestDto, Post post, Long requestUserId) {
+                PostUpdateRequest requestDto, Post post, User user) {
 
             if (!Boolean.TRUE.equals(requestDto.getRequestApproval())) {
                 return null;
@@ -72,7 +73,7 @@ public class PostUpdateRequest {
 
             return Request.builder()
                     .post(post)
-                    .requestUserId(requestUserId)
+                    .responder(user)
                     .approveStatus(RequestStatus.STATUS_PENDING)
                     .build();
         }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/RequestCreateRequest.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/dto/request/RequestCreateRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
+import org.etmetmy.bn_server.domain.user.entity.User;
 
 @Getter
 @NoArgsConstructor
@@ -14,10 +15,10 @@ import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
 public class RequestCreateRequest {
 
     public static class Converter{
-        public static Request toEntity(Post post,Long loginUserId){
+        public static Request toEntity(Post post, User user){
             return Request.builder()
                     .post(post)
-                    .requestUserId(loginUserId)
+                    .responder(user)
                     .approveStatus(RequestStatus.STATUS_PENDING)
                     .build();
         }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/entity/Request.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/entity/Request.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.etmetmy.bn_server.domain.user.entity.User;
 import org.etmetmy.bn_server.global.entity.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -26,11 +27,9 @@ public class Request extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(name = "request_user_id")
-    private Long requestUserId;
-
-    @Column(name = "replit_user_id")
-    private Long replitUserId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_user_id")
+    private User responder;
 
     @Column(name = "approve_status", length = 255)
     private RequestStatus approveStatus;
@@ -41,8 +40,8 @@ public class Request extends BaseEntity {
     @Column(name = "reject_reason", length = 255)
     private String rejectReason;
 
-    public void updateStatus(RequestStatus status, Long loginUserId, String rejectReason) {
-        this.replitUserId = loginUserId;
+    public void updateStatus(RequestStatus status, User responder, String rejectReason) {
+        this.responder = responder;
         this.approveStatus = status;
         this.rejectReason = rejectReason;
         this.replyTime = LocalDateTime.now();

--- a/src/main/java/org/etmetmy/bn_server/domain/post/repository/RequestRepository.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/repository/RequestRepository.java
@@ -25,4 +25,13 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     // 여러 Post ID로 Request 일괄 조회 (모든 상태 포함, N+1 문제 방지)
     @Query("SELECT r FROM Request r WHERE r.post.postId IN :postIds")
     List<Request> findByPostPostIdIn(@Param("postIds") List<Long> postIds);
+
+    @Query("""
+    SELECT r.approveStatus, COUNT(r)
+    FROM Request r
+    JOIN r.post p
+    WHERE p.project.id IN :projectIds
+    GROUP BY r.approveStatus
+    """)
+    List<Object[]> countByStatus(@Param("projectIds") List<Long> projectIds);
 }

--- a/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/post/service/PostServiceImpl.java
@@ -100,7 +100,7 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.REQUEST_PENDING_NOT_FOUND));
 
         // 2. Request 상태를 '승인'으로 업데이트
-        currentRequest.updateStatus(RequestStatus.STATUS_APPROVED, loginUserId, null);
+        currentRequest.updateStatus(RequestStatus.STATUS_APPROVED, user, null);
         requestRepository.save(currentRequest);
     }
 
@@ -126,7 +126,7 @@ public class PostServiceImpl implements PostService {
         fileService.saveFiles(currentRequest, reject.getFileIds(), loginUserId);
 
         // 4. Request 상태를 '거절'로 업데이트
-        currentRequest.updateStatus(RequestStatus.STATUS_REJECTED, loginUserId, reject.getRejectReason());
+        currentRequest.updateStatus(RequestStatus.STATUS_REJECTED, user, reject.getRejectReason());
         requestRepository.save(currentRequest);
     }
 
@@ -198,7 +198,7 @@ public class PostServiceImpl implements PostService {
         Post savedPost = postRepository.save(post);
 
         // 2. 승인요청이 있는 경우에만 Request 엔티티 생성 (초기 상태: PENDING)
-        Request request = PostCreateRequest.Converter.toRequestEntity(requestDto, savedPost, loginUserId);
+        Request request = PostCreateRequest.Converter.toRequestEntity(requestDto, savedPost, user);
         if (request != null) {
             requestRepository.save(request);
         }
@@ -224,6 +224,7 @@ public class PostServiceImpl implements PostService {
         // 1. 게시글 조회
         Post post = postRepository.findById(postId)
                 .orElseThrow(BoardNotFoundException::new);
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
 
         // 2. 작성자 권한 검증 (작성자만 수정 가능)
         if (!post.getUser().getId().equals(loginUserId)) {
@@ -319,7 +320,7 @@ public class PostServiceImpl implements PostService {
                 // 승인요청을 원하는 경우
                 if (existingRequest == null) {
                     // 기존 승인요청이 없으면 새로 생성
-                    Request newRequest = PostUpdateRequest.Converter.toRequestEntity(requestDto, post, loginUserId);
+                    Request newRequest = PostUpdateRequest.Converter.toRequestEntity(requestDto, post, user);
                     requestRepository.save(Objects.requireNonNull(newRequest));
                 }
                 // 이미 PENDING 상태의 승인요청이 있으면 그대로 유지

--- a/src/main/java/org/etmetmy/bn_server/domain/request/controller/RequestController.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/controller/RequestController.java
@@ -1,0 +1,48 @@
+package org.etmetmy.bn_server.domain.request.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
+import org.etmetmy.bn_server.domain.request.dto.ApprovalNotiResponse;
+import org.etmetmy.bn_server.domain.request.service.RequestService;
+import org.etmetmy.bn_server.global.CommonResponse;
+import org.etmetmy.bn_server.global.util.SessionUtil;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Request", description = "승인 요청 알림 API")
+@RestController
+@RequestMapping("/api/v1/admin/projects")
+@RequiredArgsConstructor
+public class RequestController {
+
+    private final RequestService requestService;
+
+    // todo: 개별 프로젝트 승인대기 화면 리스트들 조회
+    @Operation(summary = "개별 프로젝트 승인 요청 목록 조회", description = "개별 프로젝트 게시글 request 항목들을 조회합니다")
+    @GetMapping("/{projectId}/approval-requests")
+    public CommonResponse<ApprovalNotiResponse> getApprovalRequests(
+            @PathVariable Long projectId, HttpSession session) {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+
+        ApprovalNotiResponse result = requestService.getApprovalRequest(projectId, loginUserId);
+
+        return CommonResponse.success("승인 요청 알림 조회 성공", result);
+    }
+
+    // todo: 전체 프로젝트 승인대기 화면 리스트들 조회
+    @Operation(summary = "전체 프로젝트 승인 요청 목록 조회", description = "전체 프로젝트 승인 대기 중인 항목들을 조회합니다")
+    @GetMapping("/approval-requests")
+    public CommonResponse<ApprovalRequestListResponse> getTotalApprovalRequests(HttpSession session) {
+        Long loginUserId = SessionUtil.getLoginUserId(session);
+
+        ApprovalRequestListResponse result = requestService.getAdminApprovalRequest(loginUserId);
+
+        return CommonResponse.success("승인 요청 알림 조회 성공", result);
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/dto/ApprovalNotiResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/dto/ApprovalNotiResponse.java
@@ -1,0 +1,24 @@
+package org.etmetmy.bn_server.domain.request.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ApprovalNotiResponse {
+
+    private SummaryDTO summary;
+    private List<CategoryDTO> categories;
+
+    public static class Converter {
+        public static ApprovalNotiResponse of(SummaryDTO summary, List<CategoryDTO> categories) {
+            return ApprovalNotiResponse.builder()
+                    .summary(summary)
+                    .categories(categories)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/dto/CategoryDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/dto/CategoryDTO.java
@@ -1,0 +1,56 @@
+package org.etmetmy.bn_server.domain.request.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CategoryDTO {
+
+    @JsonProperty("stage_id")
+    private Long stageId;
+
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @JsonProperty("total_cnt")
+    private Long totalCnt;
+
+    private List<PostApprovalRequestDto> requests;
+
+    public static class Converter {
+        public static CategoryDTO of(Long stageId, String categoryName, List<PostApprovalRequestDto> posts) {
+            return CategoryDTO.builder()
+                    .stageId(stageId)
+                    .categoryName(categoryName)
+                    .totalCnt((long)posts.size())
+                    .requests(posts)
+                    .build();
+        }
+
+        public static List<CategoryDTO> fromAll(List<PostApprovalRequestDto> posts) {
+            // Stage 별로 그룹화
+            Map<Long, List<PostApprovalRequestDto>> groupedByStageId = posts.stream()
+                    .collect(Collectors.groupingBy(PostApprovalRequestDto::getStageId));
+
+            // StageId 순서로 정렬하여 CategoryDTO 생성
+            return groupedByStageId.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .map(entry -> {
+                        Long stageId = entry.getKey();
+                        List<PostApprovalRequestDto> stagePosts = entry.getValue();
+                        String stageName = stagePosts.isEmpty() ? null : stagePosts.get(0).getStageName();
+                        return of(stageId, stageName, stagePosts);
+                    })
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/dto/PostApprovalRequestDto.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/dto/PostApprovalRequestDto.java
@@ -1,0 +1,69 @@
+package org.etmetmy.bn_server.domain.request.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PostApprovalRequestDto {
+
+    @JsonProperty("post_id")
+    private Long postId;
+
+    @JsonProperty("post_title")
+    private String postTitle;
+
+    @JsonProperty("approval_status")
+    private String approvalStatus;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("responded_at")
+    private LocalDateTime respondedAt;
+
+    @JsonProperty("responder")
+    private String responder;
+
+    @JsonProperty("rejection_reason")
+    private String rejectionReason;
+
+    @JsonProperty("stage_id")
+    private Long stageId;
+
+    @JsonProperty("stage_name")
+    private String stageName;
+
+    private List<String> links;
+    private final List<FileInfoDTO> files;
+
+
+    public static class Converter {
+        public static List<PostApprovalRequestDto> from(List<Post> posts) {
+            return posts.stream()
+                    .map(post-> PostApprovalRequestDto.builder()
+                            .postId(post.getPostId())
+                            .postTitle(post.getTitle())
+                            .approvalStatus(post.getRequest().getApproveStatus().getDescription())
+                            .createdAt(post.getCreatedAt())
+                            .respondedAt(post.getRequest() != null ? post.getRequest().getReplyTime() : null)
+                            .responder(post.getRequest() != null && post.getRequest().getResponder() != null
+                                    ? post.getRequest().getResponder().getName()
+                                    : null)
+                            .rejectionReason(post.getRequest() != null ? post.getRequest().getRejectReason() : null)
+                            .stageId(post.getStage() != null ? post.getStage().getId() : null)
+                            .stageName(post.getStage() != null ? post.getStage().getStageName() : null)
+                            .build()
+                    )
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/dto/PostApprovalRequestDto.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/dto/PostApprovalRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
+import org.etmetmy.bn_server.domain.link.entity.Link;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
@@ -43,7 +44,7 @@ public class PostApprovalRequestDto {
     private String stageName;
 
     private List<String> links;
-    private final List<FileInfoDTO> files;
+    private List<FileInfoDTO> files;
 
 
     public static class Converter {
@@ -61,6 +62,15 @@ public class PostApprovalRequestDto {
                             .rejectionReason(post.getRequest() != null ? post.getRequest().getRejectReason() : null)
                             .stageId(post.getStage() != null ? post.getStage().getId() : null)
                             .stageName(post.getStage() != null ? post.getStage().getStageName() : null)
+                            // 거절된 request에 대한 파일, 링크
+                            .files(post.getRequest() != null && post.getRequest().getFiles() != null
+                                    ? FileInfoDTO.Converter.from(post.getRequest().getFiles().stream().toList())
+                                    : List.of())
+                            .links(post.getRequest() != null && post.getRequest().getLinks() != null
+                                    ? post.getRequest().getLinks().stream()
+                                            .map(Link::getLinkUrl)
+                                            .toList()
+                                    : List.of())
                             .build()
                     )
                     .toList();

--- a/src/main/java/org/etmetmy/bn_server/domain/request/dto/SummaryDTO.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/dto/SummaryDTO.java
@@ -1,0 +1,50 @@
+package org.etmetmy.bn_server.domain.request.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SummaryDTO {
+
+    @JsonProperty("pending_cnt")
+    private Long pendingCnt;
+
+    @JsonProperty("approved_cnt")
+    private Long approvedCnt;
+
+    @JsonProperty("rejected_cnt")
+    private Long rejectedCnt;
+
+    public static class Converter {
+        public static SummaryDTO from(List<Object[]> statusCounts) {
+            Long pendingCnt = 0L;
+            Long approvedCnt = 0L;
+            Long rejectedCnt = 0L;
+
+            for (Object[] row : statusCounts) {
+                RequestStatus status = (RequestStatus) row[0];
+                Long count = (Long) row[1];
+
+                switch (status) {
+                    case STATUS_PENDING -> pendingCnt = count;
+                    case STATUS_APPROVED -> approvedCnt = count;
+                    case STATUS_REJECTED -> rejectedCnt = count;
+                }
+            }
+            return SummaryDTO.builder()
+                    .pendingCnt(pendingCnt)
+                    .approvedCnt(approvedCnt)
+                    .rejectedCnt(rejectedCnt)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/service/RequestService.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/service/RequestService.java
@@ -1,0 +1,12 @@
+package org.etmetmy.bn_server.domain.request.service;
+
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
+import org.etmetmy.bn_server.domain.request.dto.ApprovalNotiResponse;
+
+
+public interface RequestService {
+
+    ApprovalNotiResponse getApprovalRequest(Long projectId, Long loginUserId);
+
+    ApprovalRequestListResponse getAdminApprovalRequest(Long loginUserId);
+}

--- a/src/main/java/org/etmetmy/bn_server/domain/request/service/RequestServiceImpl.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/request/service/RequestServiceImpl.java
@@ -1,0 +1,82 @@
+package org.etmetmy.bn_server.domain.request.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.RequiredArgsConstructor;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestListResponse;
+import org.etmetmy.bn_server.domain.dashboard.dto.response.ApprovalRequestResponse;
+import org.etmetmy.bn_server.domain.post.entity.Post;
+import org.etmetmy.bn_server.domain.post.repository.PostRepository;
+import org.etmetmy.bn_server.domain.post.repository.RequestRepository;
+import org.etmetmy.bn_server.domain.project.entity.Project;
+import org.etmetmy.bn_server.domain.project.repository.ProjectMemberRepository;
+import org.etmetmy.bn_server.domain.project.repository.ProjectRepository;
+import org.etmetmy.bn_server.domain.request.dto.ApprovalNotiResponse;
+import org.etmetmy.bn_server.domain.request.dto.CategoryDTO;
+import org.etmetmy.bn_server.domain.request.dto.PostApprovalRequestDto;
+import org.etmetmy.bn_server.domain.request.dto.SummaryDTO;
+import org.etmetmy.bn_server.domain.user.entity.Role;
+import org.etmetmy.bn_server.domain.user.entity.User;
+import org.etmetmy.bn_server.domain.user.repository.UserRepository;
+import org.etmetmy.bn_server.exception.code.ErrorCode;
+import org.etmetmy.bn_server.exception.custom.BusinessException;
+import org.etmetmy.bn_server.exception.custom.ProjectNotFoundException;
+import org.etmetmy.bn_server.exception.custom.UserNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RequestServiceImpl implements RequestService {
+
+    private final UserRepository userRepository;
+    private final RequestRepository requestRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final PostRepository postRepository;
+    private final ProjectRepository projectRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApprovalNotiResponse getApprovalRequest(Long projectId, Long loginUserId) {
+
+        // 유저 검증
+        User user = userRepository.findById(loginUserId).orElseThrow(UserNotFoundException::new);
+        Project project = projectRepository.findById(projectId).orElseThrow(ProjectNotFoundException::new);
+
+        // 프로젝트 접근 권한 확인 (ADMIN은 모든 프로젝트 접근 가능)
+        if (user.getRole() != Role.ADMIN) {
+            if (!projectMemberRepository.existsByProjectIdAndUserId(projectId, user.getId()))
+                throw new BusinessException(ErrorCode.PROJECT_PERMISSION_DENIED);
+        }
+
+        // 특정 프로젝트의 Request가 있는 Post 조회
+        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequestByProjectIds(List.of(projectId));
+        List<PostApprovalRequestDto> allPosts = PostApprovalRequestDto.Converter.from(allPostsWithRequest);
+
+        // 1. 상태별 count (DB)
+        List<Object[]> statusCounts = requestRepository.countByStatus(List.of(projectId));
+        SummaryDTO summary = SummaryDTO.Converter.from(statusCounts);
+
+        // 2. Stage별 카테고리 나누기
+        List<CategoryDTO> categories = CategoryDTO.Converter.fromAll(allPosts);
+
+        // 3. 응답 생성
+        return ApprovalNotiResponse.Converter.of(summary, categories);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ApprovalRequestListResponse getAdminApprovalRequest(Long loginUserId) {
+        // 유저 검증
+        userRepository.findById(loginUserId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // Request가 있는 모든 Post 조회 (상태별, 단계별 카운팅 및 리스트 생성용)
+        List<Post> allPostsWithRequest = postRepository.findAllPostsWithRequest();
+        List<ApprovalRequestResponse> allPosts = ApprovalRequestResponse.Converter.from(allPostsWithRequest);
+
+        // Converter 에서 단계별 필터링 및 응답 생성
+        return ApprovalRequestListResponse.Converter.of(allPosts);
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
개별 프로젝트의 승인 요청 목록을 Stage(단계)별로 분류하여 조회하는 API입니다.

### 주요 기능

  - 엔드포인트: `GET /api/v1/admin/projects/{projectId}/approval-requests`
  - 권한 검증: 프로젝트 멤버 또는 ADMIN만 접근 가능
  - 응답 구조:
    - summary: 승인 상태별 카운트 (승인 대기/승인/거절)
    - categories: Stage별로 그룹화된 승인 요청 목록 (Stage ID 오름차순 정렬)

### 구현 내용

  1. DTO 구조

 ```
 ApprovalNotiResponse
  ├── SummaryDTO (승인 상태별 카운트)
  │   ├── pending_cnt
  │   ├── approved_cnt
  │   └── rejected_cnt
  └── List<CategoryDTO> (Stage별 분류)
      └── CategoryDTO
          ├── stage_id
          ├── category_name (Stage 이름)
          ├── total_cnt
          └── requests (List<PostApprovalRequestDto>)
```

  2. 핵심 로직

  - 상태별 집계: Repository에서 JPQL로 한 번에 집계
  - Stage별 분류: Stream API로 stageId 기준 그룹화 및 정렬
  - Null 안전성: Request, Responder, Stage 필드에 null 체크 적용
  - 거절된 게시글에 대해서만 거절사유 속 파일, 링크 조회

  3. 주요 파일

  - Controller: RequestController.java
  - Service: RequestServiceImpl.java
  - Repository: RequestRepository.countByStatus()
  - DTOs: ApprovalNotiResponse, CategoryDTO, PostApprovalRequestDto, SummaryDTO

### 특징

  - Stage ID 순서로 자동 정렬
  - DB 쿼리 최적화 (상태별 카운트를 한 번의 쿼리로 처리)
  - Converter 패턴으로 변환 로직 분리
  - NPE 방지를 위한 null 체크
<img width="1174" height="848" alt="image" src="https://github.com/user-attachments/assets/377d1105-4080-41d6-8cda-eef95052f287" />
<img width="1099" height="608" alt="image" src="https://github.com/user-attachments/assets/80b48264-e2a9-457d-966b-5c9b122a70c0" />

## 📎 Issue 335

<!-- closed #335  -->
