### PR TITLE
Fix/ 전체 프로젝트 승인요청 알림 페이지에서 반환값 수정

### DIFF
--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
@@ -58,7 +58,7 @@ public class ApprovalRequestResponse {
 
     private List<FileInfo> files;
 
-    private List<LinkInfo> links;
+    private List<String> links;
 
     @Getter
     @Builder
@@ -113,7 +113,7 @@ public class ApprovalRequestResponse {
             LocalDateTime replyTime = null;
             String rejectReason = null;
             List<FileInfo> files = null;
-            List<LinkInfo> links = null;
+            List<String> links = null;
 
             if (isProcessed) {
                 // responder 이름 안전하게 가져오기
@@ -143,14 +143,11 @@ public class ApprovalRequestResponse {
                         .collect(Collectors.toList());
                 }
 
-                // 링크 목록
+                // 링크 목록 (URL만 추출)
                 if (request.getLinks() != null) {
                     links = request.getLinks().stream()
                         .filter(link -> !link.getIsDeleted())
-                        .map(link -> LinkInfo.builder()
-                            .linkId(link.getLinkId())
-                            .linkUrl(link.getLinkUrl())
-                            .build())
+                        .map(link -> link.getLinkUrl())
                         .collect(Collectors.toList());
                 }
             }

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
@@ -1,6 +1,5 @@
 package org.etmetmy.bn_server.domain.dashboard.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,8 +15,10 @@ import java.util.stream.Collectors;
 @Getter
 @Builder
 @AllArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApprovalRequestResponse {
+
+    @JsonProperty("project_id")
+    private Long projectId;
 
     @JsonProperty("post_id")
     private Long postId;
@@ -25,8 +26,18 @@ public class ApprovalRequestResponse {
     @JsonProperty("post_title")
     private String postTitle;
 
-    @JsonProperty("")
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("created_ip")
+    private String createdIp;
+
+    @JsonProperty("author_name")
+    private String authorName;
+
     private RequestStatus requestStatus;
     private String postStageName;
 
@@ -36,9 +47,116 @@ public class ApprovalRequestResponse {
 
     private String approveStatus;
 
+    @JsonProperty("responder_name")
+    private String responderName;
+
+    @JsonProperty("reply_time")
+    private LocalDateTime replyTime;
+
+    @JsonProperty("reject_reason")
+    private String rejectReason;
+
+    private List<FileInfo> files;
+
+    private List<LinkInfo> links;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class FileInfo {
+        @JsonProperty("file_id")
+        private Long fileId;
+
+        @JsonProperty("original_file_title")
+        private String originalFileTitle;
+
+        @JsonProperty("file_path")
+        private String filePath;
+
+        @JsonProperty("file_size")
+        private String fileSize;
+
+        @JsonProperty("file_type")
+        private String fileType;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LinkInfo {
+        @JsonProperty("link_id")
+        private Long linkId;
+
+        @JsonProperty("link_url")
+        private String linkUrl;
+    }
+
     public static class Converter {
         public static ApprovalRequestResponse from(Post post, Request request) {
+            // author 이름 안전하게 가져오기
+            String authorName = null;
+            if (post.getUser() != null) {
+                try {
+                    authorName = post.getUser().getName();
+                } catch (Exception e) {
+                    // EntityNotFoundException 또는 LazyInitializationException 무시
+                    authorName = null;
+                }
+            }
+
+            // 승인/거절 여부 확인 (대기 중이 아닐 때만 관련 정보 설정)
+            boolean isProcessed = request != null &&
+                                  request.getApproveStatus() != null &&
+                                  request.getApproveStatus() != RequestStatus.STATUS_PENDING;
+
+            String responderName = null;
+            LocalDateTime replyTime = null;
+            String rejectReason = null;
+            List<FileInfo> files = null;
+            List<LinkInfo> links = null;
+
+            if (isProcessed) {
+                // responder 이름 안전하게 가져오기
+                if (request.getResponder() != null) {
+                    try {
+                        responderName = request.getResponder().getName();
+                    } catch (Exception e) {
+                        // EntityNotFoundException 또는 LazyInitializationException 무시
+                        responderName = null;
+                    }
+                }
+
+                replyTime = request.getReplyTime();
+                rejectReason = request.getRejectReason();
+
+                // 파일 목록
+                if (request.getFiles() != null) {
+                    files = request.getFiles().stream()
+                        .filter(file -> !file.getIsDeleted())
+                        .map(file -> FileInfo.builder()
+                            .fileId(file.getFileId())
+                            .originalFileTitle(file.getOriginalFileTitle())
+                            .filePath(file.getFilePath())
+                            .fileSize(file.getFileSize())
+                            .fileType(file.getFileType())
+                            .build())
+                        .collect(Collectors.toList());
+                }
+
+                // 링크 목록
+                if (request.getLinks() != null) {
+                    links = request.getLinks().stream()
+                        .filter(link -> !link.getIsDeleted())
+                        .map(link -> LinkInfo.builder()
+                            .linkId(link.getLinkId())
+                            .linkUrl(link.getLinkUrl())
+                            .build())
+                        .collect(Collectors.toList());
+                }
+            }
+
             return ApprovalRequestResponse.builder()
+                    .projectId(post.getProject().getId())
                     .postId(post.getPostId())
                     .postTitle(post.getTitle())
                     .projectName(post.getProject().getProjectName())
@@ -46,7 +164,15 @@ public class ApprovalRequestResponse {
                     .postStageName(post.getStage().getStageName())
                     .approveStatus(request != null && request.getApproveStatus() != null ? request.getApproveStatus().getDescription() : null)
                     .createdAt(post.getCreatedAt())
+                    .updatedAt(post.getUpdatedAt())
+                    .createdIp(post.getCreatedIp())
+                    .authorName(authorName)
                     .requestStatus(post.getRequest().getApproveStatus())
+                    .responderName(responderName)
+                    .replyTime(replyTime)
+                    .rejectReason(rejectReason)
+                    .files(files)
+                    .links(links)
                     .build();
         }
 

--- a/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
+++ b/src/main/java/org/etmetmy/bn_server/domain/dashboard/dto/response/ApprovalRequestResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.etmetmy.bn_server.domain.file.dto.response.FileInfoDTO;
 import org.etmetmy.bn_server.domain.post.entity.Post;
 import org.etmetmy.bn_server.domain.post.entity.Request;
 import org.etmetmy.bn_server.domain.post.entity.RequestStatus;
@@ -56,40 +57,9 @@ public class ApprovalRequestResponse {
     @JsonProperty("reject_reason")
     private String rejectReason;
 
-    private List<FileInfo> files;
+    private List<FileInfoDTO> files;
 
     private List<String> links;
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class FileInfo {
-        @JsonProperty("file_id")
-        private Long fileId;
-
-        @JsonProperty("original_file_title")
-        private String originalFileTitle;
-
-        @JsonProperty("file_path")
-        private String filePath;
-
-        @JsonProperty("file_size")
-        private String fileSize;
-
-        @JsonProperty("file_type")
-        private String fileType;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class LinkInfo {
-        @JsonProperty("link_id")
-        private Long linkId;
-
-        @JsonProperty("link_url")
-        private String linkUrl;
-    }
 
     public static class Converter {
         public static ApprovalRequestResponse from(Post post, Request request) {
@@ -112,7 +82,7 @@ public class ApprovalRequestResponse {
             String responderName = null;
             LocalDateTime replyTime = null;
             String rejectReason = null;
-            List<FileInfo> files = null;
+            List<FileInfoDTO> files = null;
             List<String> links = null;
 
             if (isProcessed) {
@@ -133,10 +103,10 @@ public class ApprovalRequestResponse {
                 if (request.getFiles() != null) {
                     files = request.getFiles().stream()
                         .filter(file -> !file.getIsDeleted())
-                        .map(file -> FileInfo.builder()
+                        .map(file -> FileInfoDTO.builder()
                             .fileId(file.getFileId())
-                            .originalFileTitle(file.getOriginalFileTitle())
-                            .filePath(file.getFilePath())
+                            .fileOriginalFileName(file.getOriginalFileTitle())
+                            .fileUrl(file.getFilePath())
                             .fileSize(file.getFileSize())
                             .fileType(file.getFileType())
                             .build())


### PR DESCRIPTION
## 📄 작업 내용 요약
승인 요청 페이지 Response 개선 및 버그를 수정했습니다.

## 수정 사항

### 1. 승인 요청 상세 정보 추가

  - author_name - 게시글 작성자 이름
  - created_ip - 작성자 IP
  - updated_at - 수정일시
  - responder_name - 승인/거절한 사람
  - reply_time - 승인/거절 시간
  - reject_reason - 거절 사유
  - files - Request에 첨부된 파일 목록 (FileInfo[])
  - links - Request에 첨부된 링크 목록 (String)

### 2. 상태별 조건부 응답 처리

  - STATUS_PENDING (대기 중): responder, reply_time, reject_reason, files, links → null
  - STATUS_APPROVED/REJECTED (처리 완료): 모든 관련 정보 포함

<img width="2410" height="1812" alt="image" src="https://github.com/user-attachments/assets/36f98fc4-7ceb-404f-8d00-bc01c70f5022" />

## 📎 Issue 351

<!-- closed #351  -->
